### PR TITLE
Temporarily fixed H613B protocol difference

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1060,6 +1060,7 @@ class GoveePlatform {
             API needs { cmd: 'color', data: { r, g, b } }
             AWS needs { cmd: 'color', data: { red, green, blue } }
             BLE needs { cmd: 0x05, data: [0x02, r, g, b] }
+            H613B needs { cmd: 0x05, data: [0x0D, r, g, b] }
           */
           data.apiParams = {
             cmd: 'color',
@@ -1109,7 +1110,7 @@ class GoveePlatform {
           }
           data.bleParams = {
             cmd: 0x05,
-            data: [0x02, params.value.r, params.value.g, params.value.b]
+            data: [accessory.context.gvModel === 'H613B' ? 0x0D : 0x02, params.value.r, params.value.g, params.value.b]
           }
           break
         }


### PR DESCRIPTION
Using `0x0D` instead of `0x02` for H613B as mentioned in #205.