### PR TITLE
h7061 h7062 colorwc

### DIFF
--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -303,6 +303,8 @@ export default {
     'H619E',
     'H61A0',
     'H7060',
+    'H7061',
+    'H7062',
   ],
 
   awsColourShort: ['H6003', 'H6086', 'H6159'],


### PR DESCRIPTION
As mentioned in #300, the device family 7060 supports colorwc. 7061 and 7062 were missing.