### PR TITLE
handle when the temCali is undefined

### DIFF
--- a/lib/device/sensor-thermo.js
+++ b/lib/device/sensor-thermo.js
@@ -92,7 +92,9 @@ export default class {
 
     // Check to see if the provided temperature is different from the cached state
     if (hasProperty(params, 'temperature')) {
-      let newTemp = parseInt(params.temperature + this.accessory.context.offTemp, 10);
+      // there are some cases when the offTemp is undefined
+      let offTemp = this.accessory.context.offTemp ?? 0
+      let newTemp = parseInt(params.temperature + offTemp, 10);
       newTemp /= 100;
       if (newTemp !== this.cacheTemp) {
         // Temperature is different so update Homebridge with new values


### PR DESCRIPTION
addresses the issue that was causing 0 degrees to be reported - the addition `parseInt` ends ups as `NaN` when the `offTemp` is undefined so default to 0

#592