### PR TITLE
Add displayName

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "homebridge-govee",
+  "displayName": "Govee",
   "alias": "Govee",
   "version": "10.2.0",
   "author": {


### PR DESCRIPTION
The display name is not currently configured. This PR adds `displayName` to package.json to make the name shown in the HomeBridge UI prettier.

![Screenshot 2023-12-18 at 18 28 59](https://github.com/bwp91/homebridge-govee/assets/591634/180063b0-930f-4f85-86e1-107c53bf4de8)
