### PR TITLE
Add support for H5105

### DIFF
--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -355,6 +355,7 @@ export default {
       'H5177',
       'H5179',
       'H5183',
+      'H5105',
     ],
     sensorThermo4: ['H5198'],
     sensorMonitor: ['H5106'],


### PR DESCRIPTION
Adds support for the new Thermo sensor model H5105 (BLE-Only)