### PR TITLE
 Update constants.js to add new H7106 fan

### DIFF
--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -388,7 +388,7 @@ export default {
     ],
     sensorThermo4: ['H5198'],
     sensorMonitor: ['H5106'],
-    fan: ['H7100', 'H7101', 'H7102', 'H7111'],
+    fan: ['H7100', 'H7101', 'H7102', 'H7106', 'H7111'],
     heater1: ['H7130', 'H713A', 'H713B', 'H713C'],
     heater2: ['H7131', 'H7132', 'H7133', 'H7134', 'H7135'],
     dehumidifier: ['H7150', 'H7151'],


### PR DESCRIPTION
Resolves #781, resolves #784, resolves #791, resolves #792

Tested with actual H7106 versionHard 1.02.00, versionSoft 1.00.10

Fan on/off and speed settings working.

Noticed issue with oscillate switch in Apple Home app, similar to issue #521. The oscillate toggle in the Home app turns oscillation on and off but:
- Immediately turns to off after being turned on, even though the fan continues to oscillate.
- Often shows the wrong state.