### PR TITLE
Fix for H5178 Temp sensor

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1087,7 +1087,7 @@
               "type": "string",
               "description": "Enter the 23/26 digit Govee Device ID to begin (e.g. 12:AB:A1:C5:A8:99:D2:17).",
               "minLength": 23,
-              "maxLength": 23
+              "maxLength": 26
             },
             "ignoreDevice": {
               "type": "boolean",

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -578,7 +578,9 @@ export default class {
           // Format device id
           if (!httpDevice.device.includes(':')) {
             // Eg converts abcd1234abcd1234 to AB:CD:12:34:AB:CD:12:34
-            httpDevice.device = httpDevice.device.replace(/..\B/g, '$&:').toUpperCase()
+            // For sensors with an add on sensor like H5178
+            // Eg converts abcd1234abcd1234_1 to AB:CD:12:34:AB:CD:12:34_1
+            httpDevice.device = httpDevice.device.replace(/([a-zA-Z0-9]{2})(?=[a-zA-Z0-9])/g, "$&:").toUpperCase()
           }
 
           // Check it's not a user-ignored device
@@ -1239,7 +1241,9 @@ export default class {
             // Reformat the device id
             if (!device.device.includes(':')) {
               // Eg converts abcd1234abcd1234 to AB:CD:12:34:AB:CD:12:34
-              device.device = device.device.replace(/..\B/g, '$&:').toUpperCase()
+              // For sensors with an add on sensor like H5178
+              // Eg converts abcd1234abcd1234_1 to AB:CD:12:34:AB:CD:12:34_1
+              device.device = device.device.replace(/([a-zA-Z0-9]{2})(?=[a-zA-Z0-9])/g, "$&:").toUpperCase()
             }
 
             // Generate the UIID from which we can match our Homebridge accessory

--- a/lib/utils/functions.js
+++ b/lib/utils/functions.js
@@ -50,7 +50,7 @@ function parseDeviceId(deviceId) {
   return deviceId
     .toString()
     .toUpperCase()
-    .replace(/[^A-F0-9:]+/g, '')
+    .replace(/[^A-F0-9_:]+/g, '')
 }
 
 function parseError(err, hideStack = []) {


### PR DESCRIPTION
Issue - could not exclude Outside sensor of H5178 because id has an underscore

- Add fix for H5178 Temp sensor that has an underscore in the device id of the outside sensor
  - This Sensor: https://www.amazon.com/Govee-Bluetooth-Humidity-Temperature-Sensor/dp/B0872ZPQSJ 

- Add fix for not being able to enter more than 23 characters for a temperature sensor in UI
    - Bumped max characters to 26 to be inline with the stated limits
    
![image](https://github.com/user-attachments/assets/69fa7fc1-3c06-4f6d-8c15-f74a223eb6a7)
