### PR TITLE
Add support for H8072 and H80C4

### DIFF
--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -330,11 +330,13 @@ export default {
       'H70C2',
       'H70C5',
       'H70D1',
+      'H8072',
       'H801B',
       'H801C',
       'H805A',
       'H805B',
       'H805C',
+      'H80C4',
       'HXXXX', // placeholder for LAN-only configured models
     ],
     rgbBT: [
@@ -560,9 +562,11 @@ export default {
     'H70BC', // https://app-h5.govee.com/user-manual/wlan-guide (2024-10-15)
     'H70C1', // https://app-h5.govee.com/user-manual/wlan-guide (2024-10-15)
     'H70C2', // https://app-h5.govee.com/user-manual/wlan-guide (2024-10-15)
+    'H8072', // https://app-h5.govee.com/user-manual/wlan-guide (2024-10-15)
     'H805A', // https://app-h5.govee.com/user-manual/wlan-guide (2024-10-15)
     'H805B', // https://app-h5.govee.com/user-manual/wlan-guide (2024-10-15)
     'H805C', // https://app-h5.govee.com/user-manual/wlan-guide (2024-10-15)
+    'H80C4', // https://app-h5.govee.com/user-manual/wlan-guide (2024-10-15)
   ],
 
   awsOutlet1617: ['H5080', 'H5083'],


### PR DESCRIPTION
## :recycle: Current situation

Govee RGBICWW Floor Lamps (H8072) and Govee Christmas String Lights S2 (H80C4) are not supported

## :bulb: Proposed solution

Add H8072 and H80C4 to the RGB constants

## :gear: Release Notes

- Added support for Govee RGBICWW Floor Lamps (H8072)
- Added support for Govee Christmas String Lights S2 (H80C4)

### Testing

Tested changes with both models which I own and are running in my living room

### Reviewer Nudging

I simply added H8072 and H80C4 in `lib/utils/contants.js` Should be a fairly simple review.