### PR TITLE
Added support for H6104 status updates from AWS

### DIFF
--- a/lib/platform.js
+++ b/lib/platform.js
@@ -1799,6 +1799,17 @@ export default class {
 
     // Standardise the object for the receiver function
     const data = {}
+	
+    // This will add support for status updates from H6104 and possibly other old devices that send the status mesage in a different structure (data instead of state)
+    if (params.data && !params.state) {
+      params.state = []
+      if (hasProperty(params.data, 'turn')) {
+        params.state.onOff = params.data.turn
+      }
+      if (hasProperty(params.data, 'brightness')) {
+        params.state.brightness = params.data.brightness
+      }
+    }
 
     /*
       ON/OFF


### PR DESCRIPTION
Govee LED TV Backlights half work as they can be turned On and Off but they are not updating status from AWS because for some reason the structure of the update message is different, I added a bit of code to copy the passed values into the expected structure so it can be used.

Example of status update messages received:

[2/23/2025, 12:50:20 PM] [Govee] [AWS] message event [{"state":{"onOff":0,"brightness":254,"device":"99:28:78:9C:E7:0C:56:E9","sku":"H6104"},"msg":"{\"data\":\"{\\\"softversion\\\":\\\"1.01.50\\\",\\\"turn\\\":0,\\\"brightness\\\":254,\\\"timer\\\":{\\\"enable\\\":0,\\\"time\\\":[{\\\"openHour\\\":0,\\\"openMin\\\":0,\\\"closeHour\\\":23,\\\"closeMin\\\":59}]}}\",\"transaction\":\"x_1740333020421\",\"sku\":\"H6104\",\"device\":\"99:28:78:9C:E7:0C:56:E9\",\"type\":0,\"cmd\":\"status\"}","proType":0}].
[2/23/2025, 12:50:20 PM] [Govee] [Family Room TV LED] [AWS] receiving update {"source":"AWS","data":{"softversion":"1.01.50","turn":0,"brightness":254,"timer":{"enable":0,"time":[{"openHour":0,"openMin":0,"closeHour":23,"closeMin":59}]}},"transaction":"x_1740333020421","sku":"H6104","device":"99:28:78:9C:E7:0C:56:E9","type":0,"cmd":"status"}.
[2/23/2025, 12:50:20 PM] [Govee] [Family Room TV LED] [AWS] unknown command in payload received: 