### PR TITLE
Add support for Govee H5109 floating temperature sensor

### DIFF
--- a/lib/device/index.js
+++ b/lib/device/index.js
@@ -46,6 +46,7 @@ import deviceSensorLeak from './sensor-leak.js'
 import deviceSensorMonitor from './sensor-monitor.js'
 import deviceSensorPresence from './sensor-presence.js'
 import deviceSensorThermo4 from './sensor-thermo4.js'
+import deviceSensorThermoH5109 from './sensor-thermo-H5109.js'
 import deviceSensorThermo from './sensor-thermo.js'
 import deviceSwitchDouble from './switch-double.js'
 import deviceSwitchSingle from './switch-single.js'
@@ -104,6 +105,7 @@ export default {
   deviceSensorMonitor,
   deviceSensorPresence,
   deviceSensorThermo,
+  deviceSensorThermoH5109,
   deviceSensorThermo4,
   deviceSwitchDouble,
   deviceSwitchSingle,

--- a/lib/device/sensor-thermo-H5109.js
+++ b/lib/device/sensor-thermo-H5109.js
@@ -1,0 +1,123 @@
+import platformConsts from '../utils/constants.js'
+import {
+  cenToFar,
+  generateRandomString,
+  hasProperty,
+  parseError,
+} from '../utils/functions.js'
+import platformLang from '../utils/lang-en.js'
+
+export default class {
+  constructor(platform, accessory) {
+    // Set up variables from the platform
+    this.hapChar = platform.api.hap.Characteristic
+    this.hapErr = platform.api.hap.HapStatusError
+    this.hapServ = platform.api.hap.Service
+    this.platform = platform
+    this.httpTimeout = platform.config.bleRefreshTime * 4.5 * 1000
+
+    // Set up variables from the accessory
+    this.accessory = accessory
+
+    // Set up custom variables for this device type
+    const deviceConf = platform.deviceConf[accessory.context.gvDeviceId]
+    this.lowBattThreshold = deviceConf && deviceConf.lowBattThreshold
+      ? Math.min(deviceConf.lowBattThreshold, 100)
+      : platformConsts.defaultValues.lowBattThreshold
+
+    // Add the temperature service if it doesn't already exist
+    this.tempService = this.accessory.getService(this.hapServ.TemperatureSensor)
+      || this.accessory.addService(this.hapServ.TemperatureSensor)
+    this.cacheTemp = this.tempService.getCharacteristic(this.hapChar.CurrentTemperature).value
+    this.updateCache()
+
+    // Add the battery service if it doesn't already exist
+    this.battService = this.accessory.getService(this.hapServ.Battery)
+      || this.accessory.addService(this.hapServ.Battery)
+    this.cacheBatt = this.battService.getCharacteristic(this.hapChar.BatteryLevel).value
+
+    // Pass the accessory to Fakegato to set up with Eve
+    this.accessory.eveService = new platform.eveService('custom', this.accessory, {
+      log: () => {},
+    })
+
+    // Output the customised options to the log
+    const opts = JSON.stringify({
+      lowBattThreshold: this.lowBattThreshold,
+    })
+    platform.log('[%s] %s %s.', accessory.displayName, platformLang.devInitOpts, opts)
+  }
+
+  async externalUpdate(params) {
+    // Check to see if the provided online status is different from the cache value
+    if (hasProperty(params, 'online') && this.cacheOnline !== params.online) {
+      this.cacheOnline = params.online
+      this.platform.updateAccessoryStatus(this.accessory, this.cacheOnline)
+    }
+
+    if (params.source === 'BLE') {
+      // If we have a BLE update then we should ignore HTTP updates for the next 4 BLE refresh cycles
+      // Since BLE will be more accurate and may not have updated with the cloud yet
+      // Generate a random key
+      const bleKey = generateRandomString(5)
+      this.bleKey = bleKey
+      setTimeout(() => {
+        if (this.bleKey === bleKey) {
+          this.bleKey = false
+        }
+      }, this.httpTimeout)
+    }
+    if (params.source === 'HTTP' && this.bleKey) {
+      return
+    }
+
+    // Check to see if the provided battery is different from the cached state
+    if (params.battery !== this.cacheBatt && this.battService) {
+      // Battery is different so update Homebridge with new values
+      this.cacheBatt = params.battery
+      this.battService.updateCharacteristic(this.hapChar.BatteryLevel, this.cacheBatt)
+      this.battService.updateCharacteristic(
+        this.hapChar.StatusLowBattery,
+        this.cacheBatt < this.lowBattThreshold ? 1 : 0,
+      )
+
+      // Log the change
+      this.accessory.log(`${platformLang.curBatt} [${this.cacheBatt}%]`)
+    }
+
+    // Check to see if the provided temperature is different from the cached state
+    if (hasProperty(params, 'temperature')) {
+      let newTemp = Number.parseInt(params.temperature + this.accessory.context.offTemp, 10)
+      newTemp /= 100
+      if (newTemp !== this.cacheTemp) {
+        // Temperature is different so update Homebridge with new values
+        this.cacheTemp = newTemp
+        this.tempService.updateCharacteristic(this.hapChar.CurrentTemperature, this.cacheTemp)
+        this.accessory.eveService.addEntry({ temp: this.cacheTemp })
+
+        // Log the change
+        this.accessory.log(`${platformLang.curTemp} [${this.cacheTemp}°C / ${cenToFar(this.cacheTemp)}°F]`)
+
+        // Update the cache file with the new temperature
+        this.updateCache()
+      }
+    }
+  }
+
+  async updateCache() {
+    // Don't continue if the storage client hasn't initialised properly
+    if (!this.platform.storageClientData) {
+      return
+    }
+
+    // Attempt to save the new temperature to the cache
+    try {
+      await this.platform.storageData.setItem(
+        `${this.accessory.context.gvDeviceId}_temp`,
+        this.cacheTemp,
+      )
+    } catch (err) {
+      this.accessory.logWarn(`${platformLang.storageWriteErr} ${parseError(err)}`)
+    }
+  }
+}

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -940,7 +940,12 @@ export default class {
         accessory = devicesInHB.get(uuid) || this.addAccessory(device)
       } else if (platformConsts.models.sensorThermo.includes(device.model)) {
         // Device is a thermo-hygrometer sensor
-        devInstance = deviceTypes.deviceSensorThermo
+        if (device.model === 'H5109') {
+          // Special handling for Gateway H5042+ with Floating Pool Sensor H5109
+          devInstance = deviceTypes.deviceSensorThermoH5109
+        } else {
+          devInstance = deviceTypes.deviceSensorThermo
+        }
         accessory = devicesInHB.get(uuid) || this.addAccessory(device)
       } else if (platformConsts.models.sensorThermo4.includes(device.model)) {
         // Device is a thermo-hygrometer sensor with 4 prongs and AWS support

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -446,6 +446,7 @@ export default {
       'H5104',
       'H5105',
       'H5108',
+      'H5109',
       'H5174',
       'H5177',
       'H5179',
@@ -475,7 +476,6 @@ export default {
       'H5121', // https://github.com/homebridge-plugins/homebridge-govee/issues/913
       'H5126', // https://github.com/homebridge-plugins/homebridge-govee/issues/910
       'H5107', // https://github.com/homebridge-plugins/homebridge-govee/issues/803
-      'H5109', // https://github.com/homebridge-plugins/homebridge-govee/issues/823
       'H5125', // https://github.com/homebridge-plugins/homebridge-govee/issues/981
       'H5185', // https://github.com/homebridge-plugins/homebridge-govee/issues/804
     ],


### PR DESCRIPTION
This pull request adds support for the Govee H5109 floating pool temperature sensor to the homebridge-govee plugin.

I've added a new device file (sensor-thermo-H5109.js) and made the necessary changes to constants.js, platform.js, and device/index.js to integrate this sensor type. The implementation allows the device to appear as a thermostat in HomeKit. I used a thermostat instead of a temperature sensor so it shows as a block on the home summary.

I want to apologize if any part of my submission is outside the norm or doesn't follow best practices. This is my first time really coding something, much less contributing to GitHub, so I'm still learning the proper workflows and coding standards.

I've tested this implementation by copying the code to my personal homebridge server where I'm using the H5109 floating sensor. The sensor successfully connects and reports temperature data to HomeKit.

Thank you for considering my contribution to this project!