### PR TITLE
Fix BLE control for H617A and other BLE-only devices (#1208)

### DIFF
--- a/lib/connection/ble.js
+++ b/lib/connection/ble.js
@@ -33,7 +33,7 @@ process.on('unhandledRejection', (reason) => {
 
 const H5075_UUID = 'ec88'
 const H5101_UUID = '0001'
-const CONTROL_CHARACTERISTIC_UUID = '000102030405060708090a0b0c0d1910'
+const CONTROL_CHARACTERISTIC_UUID = '000102030405060708090a0b0c0d2b11'
 const CONNECTION_TIMEOUT = 10000 // 10 seconds
 const WRITE_TIMEOUT = 5000 // 5 seconds
 
@@ -237,6 +237,8 @@ export default class BLEConnection {
       )
 
       if (!characteristic) {
+        const discoveredUuids = Object.values(characteristics).map(c => c.uuid)
+        accessory.logDebug(`discovered characteristics: ${JSON.stringify(discoveredUuids)}`)
         throw new Error('Control characteristic not found')
       }
       accessory.logDebug('found control characteristic')

--- a/lib/connection/ble.js
+++ b/lib/connection/ble.js
@@ -4,7 +4,7 @@ import process from 'node:process'
 import btClient from '@stoprocent/noble'
 
 import { decodeAny } from '../utils/decode.js'
-import { base64ToHex, generateCodeFromHexValues, hexToTwoItems } from '../utils/functions.js'
+import { base64ToHex, generateCodeFromHexValues, hexToTwoItems, sleep } from '../utils/functions.js'
 import platformLang from '../utils/lang-en.js'
 import { isValidPeripheral } from '../utils/validation.js'
 
@@ -222,7 +222,7 @@ export default class BLEConnection {
       btClient.reset()
 
       // Connect with timeout
-      accessory.logDebug('connecting to device at %s', accessory.context.bleAddress)
+      accessory.logDebug(`connecting to device at ${accessory.context.bleAddress}`)
       peripheral = await this.connectWithTimeout(accessory.context.bleAddress, CONNECTION_TIMEOUT)
       this.activeConnection = peripheral
       accessory.logDebug('connected successfully')
@@ -247,9 +247,10 @@ export default class BLEConnection {
       const finalBuffer = this.prepareCommandBuffer(params)
       accessory.logDebug(`sending command: ${finalBuffer.toString('hex')}`)
 
-      // Write with timeout
+      // Write without response then allow time for the BLE controller to transmit before disconnecting
       await this.writeWithTimeout(characteristic, finalBuffer, WRITE_TIMEOUT)
       accessory.logDebug('command sent successfully')
+      await sleep(100)
     } catch (err) {
       accessory.logWarn(`BLE update failed: ${err.message}`)
       throw err
@@ -265,7 +266,7 @@ export default class BLEConnection {
           await peripheral.disconnectAsync()
           accessory.logDebug('disconnected')
         } catch (err) {
-          accessory.logDebug('disconnect error (non-critical): %s', err.message)
+          accessory.logDebug(`disconnect error (non-critical): ${err.message}`)
         }
       }
 


### PR DESCRIPTION
## :recycle: Current situation

BLE-only devices (such as the H617A light strip) fail with **"Control characteristic not found"** when attempting to control them via Bluetooth, as reported in #1208. The device connects successfully and services are discovered, but the plugin searches for the wrong characteristic UUID, so no commands can be sent. This makes BLE-only devices non-functional.

The root cause is a regression introduced in 14f3bd8 ("simplify BLE connections and updates"). During that refactoring, the BLE **service** UUID (`000102030405060708090a0b0c0d1910`) was used in place of the **write characteristic** UUID (`000102030405060708090a0b0c0d2b11`). The old code even had a comment distinguishing the two: `// Service UUID for future reference 000102030405060708090a0b0c0d1910`.

Also re-added a 100ms delay that allows the command a chance to send before the connection is torn down.

Fixed a few `logDebug` calls using printf-style `%s` placeholders, which didn't work because `logDebug` only accepts a single string argument.

## :bulb: Proposed solution

**Commit 1** — Fix the characteristic UUID and add diagnostic logging:
- Restore the correct write characteristic UUID (`...2b11`)
- When the characteristic is not found, log all discovered characteristic UUIDs at debug level to aid future diagnosis of similar issues

**Commit 2** — Fix write timing and debug log formatting:
- Restore the 100ms post-write delay before disconnecting, matching the original working implementation
- Convert broken `logDebug('%s', value)` calls to template literals

All changes are in a single file: `lib/connection/ble.js`.

## :gear: Release Notes

- **Fixed:** BLE-only devices (e.g. H617A) now respond to control commands. A regression had caused "Control characteristic not found" errors, making these devices non-functional.

## :heavy_plus_sign: Additional Information

The correct UUIDs are confirmed by:
- The original source code prior to the regression
- [H617A reverse engineering](https://community.home-assistant.io/t/govee-h617a-ble-led-strip-lights-reverse-engineering/901353)
- [H6127 reverse engineering](https://github.com/BeauJBurroughs/Govee-H6127-Reverse-Engineering)

Both document the Govee BLE protocol as:
- Service UUID: `00010203-0405-0607-0809-0a0b0c0d1910`
- Write Characteristic UUID: `00010203-0405-0607-0809-0a0b0c0d2b11`

### Testing

Tested on a Govee H617A RGBIC LED strip (BLE-only device) running on a Linux server with Homebridge v1.11.2. Verified:
- Device connects and discovers the control characteristic
- On/off commands are received and executed by the device
- Brightness and colour commands work
- Consecutive commands work reliably

Logs:

```
[2/9/2026, 12:02:07 PM] [Govee] [RGBIC Strip Lights] starting ble update with params [{"cmd":1,"data":0}].
[2/9/2026, 12:02:07 PM] [Govee] [RGBIC Strip Lights] connecting to device at e4:xx:xx:xx:xx:59.
[2/9/2026, 12:02:08 PM] [Govee] [BLE] sensor data from e4:5e:85:c6:25:59: 0388ec000a0100.
[2/9/2026, 12:02:08 PM] [Govee] [RGBIC Strip Lights] connected successfully.
[2/9/2026, 12:02:08 PM] [Govee] [RGBIC Strip Lights] discovering services and characteristics.
[2/9/2026, 12:02:08 PM] [Govee] [RGBIC Strip Lights] found control characteristic.
[2/9/2026, 12:02:08 PM] [Govee] [RGBIC Strip Lights] sending command: 3301000000000000000000000000000000000032.
[2/9/2026, 12:02:08 PM] [Govee] [RGBIC Strip Lights] command sent successfully.
[2/9/2026, 12:02:08 PM] [Govee] [RGBIC Strip Lights] disconnecting from device.
[2/9/2026, 12:02:08 PM] [Govee] [RGBIC Strip Lights] disconnected.
[2/9/2026, 12:02:08 PM] [Govee] [RGBIC Strip Lights] current state [off].
[2/9/2026, 12:02:12 PM] [Govee] [RGBIC Strip Lights] starting ble update with params [{"cmd":1,"data":1}].
[2/9/2026, 12:02:12 PM] [Govee] [RGBIC Strip Lights] connecting to device at e4:xx:xx:xx:xx:59.
[2/9/2026, 12:02:13 PM] [Govee] [RGBIC Strip Lights] connected successfully.
[2/9/2026, 12:02:13 PM] [Govee] [RGBIC Strip Lights] discovering services and characteristics.
[2/9/2026, 12:02:13 PM] [Govee] [RGBIC Strip Lights] found control characteristic.
[2/9/2026, 12:02:13 PM] [Govee] [RGBIC Strip Lights] sending command: 3301010000000000000000000000000000000033.
[2/9/2026, 12:02:13 PM] [Govee] [RGBIC Strip Lights] command sent successfully.
[2/9/2026, 12:02:13 PM] [Govee] [RGBIC Strip Lights] disconnecting from device.
[2/9/2026, 12:02:13 PM] [Govee] [RGBIC Strip Lights] disconnected.
[2/9/2026, 12:02:13 PM] [Govee] [RGBIC Strip Lights] current state [on].
```

### Reviewer Nudging

Start with `lib/connection/ble.js` line 36 — the UUID constant. Then look at the `updateDevice()` method starting around line 200 for the write + sleep change. The diff is small and self-contained.
