### PR TITLE
Add Govee OpenAPI support and API key config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ Homebridge plugin to integrate Govee devices into HomeKit
 ### Plugin Information
 
 - This plugin allows you to view and control your Govee devices within HomeKit. The plugin:
-  - requires your Govee credentials for most device models and Cloud/BLE connections
+  - supports Govee OpenAPI discovery/state/control when an OpenAPI key is provided
+  - requires your Govee credentials for most Cloud/AWS/BLE connections
   - can control certain models locally via LAN control without any Govee credentials
-  - does **not** make use of the Govee API key
+  - may use different connection methods depending on device model and account capabilities
 
 > I'm looking for some lovely people to help maintain this plugin, please get in touch on GitHub or Discord if you'd like to help out 😄
 
@@ -43,6 +44,7 @@ Homebridge plugin to integrate Govee devices into HomeKit
 
 - [Supported Devices](https://github.com/homebridge-plugins/homebridge-govee/wiki/Supported-Devices)
 - [Connection Methods](https://github.com/homebridge-plugins/homebridge-govee/wiki/Connection-Methods)
+  - OpenAPI Control
   - [LAN Control](https://github.com/homebridge-plugins/homebridge-govee/wiki/LAN-Control)
   - [AWS Control](https://github.com/homebridge-plugins/homebridge-govee/wiki/AWS-Control)
   - [BLE Control](https://github.com/homebridge-plugins/homebridge-govee/wiki/Bluetooth-Control)

--- a/config.schema.json
+++ b/config.schema.json
@@ -14,6 +14,11 @@
         "type": "string",
         "default": "Govee"
       },
+      "apiKey": {
+        "type": "string",
+        "title": "Govee OpenAPI Key",
+        "description": "Optional. Used for Govee OpenAPI discovery/state/control when available. This is separate from the app login used for AWS/BLE connections."
+      },
       "username": {
         "type": "string",
         "title": "Govee Email",
@@ -29,7 +34,7 @@
         "title": "Ignore Matter Devices",
         "description": "If enabled, the plugin will not set up Matter-enabled models.",
         "condition": {
-          "functionBody": "return (model.username && model.password);"
+          "functionBody": "return ((model.username && model.password) || model.apiKey);"
         }
       },
       "httpRefreshTime": {
@@ -1436,6 +1441,7 @@
       "type": "fieldset",
       "title": "Required Settings",
       "items": [
+        "apiKey",
         "username",
         "password"
       ]

--- a/lib/connection/openapi.js
+++ b/lib/connection/openapi.js
@@ -151,7 +151,7 @@ function findOptionByName(capability, name) {
 function validateRangeValue(capability, value, cmd) {
   const numeric = Number(value)
   if (!Number.isFinite(numeric)) {
-    throw new Error(`invalid numeric value for ${cmd}`)
+    throw new TypeError(`invalid numeric value for ${cmd}`)
   }
 
   const range = findRange(capability)

--- a/lib/connection/openapi.js
+++ b/lib/connection/openapi.js
@@ -1,0 +1,401 @@
+import axios from 'axios'
+
+import { parseError } from '../utils/functions.js'
+
+const BASE_URL = 'https://openapi.api.govee.com'
+
+function normalizeOptions(options = []) {
+  return Array.isArray(options) ? options.filter(option => option && Object.hasOwn(option, 'value')) : []
+}
+
+function capabilityLookup(capabilities = []) {
+  const byInstance = {}
+  capabilities.forEach((capability) => {
+    if (capability?.instance) {
+      byInstance[capability.instance] = capability
+    }
+  })
+  return byInstance
+}
+
+function findRange(capability) {
+  const range = capability?.parameters?.range
+    || capability?.range
+    || capability?.options?.range
+    || capability?.struct?.range
+  if (!range) {
+    return null
+  }
+  const min = Number(range.min)
+  const max = Number(range.max)
+  return Number.isFinite(min) && Number.isFinite(max)
+    ? { min, max }
+    : null
+}
+
+function intToRgb(value) {
+  const rgb = Number(value)
+  if (!Number.isFinite(rgb)) {
+    return null
+  }
+  return {
+    r: (rgb >> 16) & 0xFF,
+    g: (rgb >> 8) & 0xFF,
+    b: rgb & 0xFF,
+  }
+}
+
+function getDevicesFromPayload(data) {
+  return data?.payload?.devices
+    || data?.data?.devices
+    || (Array.isArray(data?.data) ? data.data : null)
+    || data?.devices
+    || (Array.isArray(data) ? data : null)
+    || []
+}
+
+function getCapabilitiesFromPayload(data) {
+  return data?.payload?.capabilities
+    || data?.payload?.state?.capabilities
+    || data?.data?.capabilities
+    || data?.capabilities
+    || []
+}
+
+function getCapabilityValue(capability) {
+  if (capability?.state && Object.hasOwn(capability.state, 'value')) {
+    return capability.state.value
+  }
+  return capability?.value
+}
+
+function getCapabilityOptions(capability) {
+  return normalizeOptions(capability?.parameters?.options)
+}
+
+function cloneCapabilities(capabilities = []) {
+  return capabilities.map(capability => ({
+    ...capability,
+    parameters: capability?.parameters
+      ? {
+          ...capability.parameters,
+          options: normalizeOptions(capability.parameters.options),
+        }
+      : capability?.parameters,
+  }))
+}
+
+function capabilityHasSceneOptions(capability) {
+  return getCapabilityOptions(capability).length > 0
+}
+
+function mergeSceneCapabilities(baseCapabilities = [], sceneCapabilities = []) {
+  if (!Array.isArray(sceneCapabilities) || sceneCapabilities.length === 0) {
+    return baseCapabilities
+  }
+
+  const scenesByInstance = {}
+  sceneCapabilities.forEach((sceneCapability) => {
+    if (sceneCapability?.instance) {
+      scenesByInstance[sceneCapability.instance] = sceneCapability
+    }
+  })
+
+  return baseCapabilities.map((capability) => {
+    const sceneCapability = scenesByInstance[capability?.instance]
+    if (!sceneCapability) {
+      return capability
+    }
+    return {
+      ...capability,
+      parameters: {
+        ...(capability?.parameters || {}),
+        ...(sceneCapability?.parameters || {}),
+        options: normalizeOptions(sceneCapability?.parameters?.options),
+      },
+    }
+  })
+}
+
+function findOptionByName(capability, name) {
+  const lowered = `${name}`.trim().toLowerCase()
+  return getCapabilityOptions(capability).find(option => `${option?.name || ''}`.trim().toLowerCase() === lowered)
+}
+
+function validateRangeValue(capability, value, cmd) {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) {
+    throw new Error(`invalid numeric value for ${cmd}`)
+  }
+
+  const range = findRange(capability)
+  if (!range) {
+    return numeric
+  }
+
+  const clamped = Math.max(range.min, Math.min(range.max, numeric))
+  if (range.precision && range.precision >= 1) {
+    return Math.round(clamped / range.precision) * range.precision
+  }
+  return clamped
+}
+
+export default class {
+  constructor(platform) {
+    this.apiKey = platform.config.apiKey
+    this.log = platform.log
+    this.platform = platform
+  }
+
+  async request({ method, path, data }) {
+    try {
+      const res = await axios({
+        url: `${BASE_URL}${path}`,
+        method,
+        headers: this.headers(),
+        data,
+        timeout: 30000,
+      })
+
+      if (Number(res?.data?.code) && Number(res.data.code) !== 200) {
+        throw new Error(res?.data?.message || res?.data?.msg || `OpenAPI code ${res.data.code}`)
+      }
+
+      return res.data
+    } catch (err) {
+      throw new Error(parseError(err))
+    }
+  }
+
+  headers() {
+    return {
+      'Content-Type': 'application/json',
+      'Govee-API-Key': this.apiKey,
+    }
+  }
+
+  async getScenes(sku, device) {
+    const data = await this.request({
+      method: 'post',
+      path: '/router/api/v1/device/scenes',
+      data: {
+        requestId: `hb-scenes-${Date.now()}`,
+        payload: { sku, device },
+      },
+    })
+
+    return getCapabilitiesFromPayload(data)
+  }
+
+  async getDevices() {
+    const data = await this.request({
+      method: 'get',
+      path: '/router/api/v1/user/devices',
+    })
+
+    const devices = getDevicesFromPayload(data)
+    const parsedDevices = await Promise.all(
+      devices
+        .filter(device => device?.sku && device?.device)
+        .map(async (device) => {
+          let capabilities = cloneCapabilities(Array.isArray(device.capabilities) ? device.capabilities : [])
+
+          if (capabilities.some(capability => capability?.type === 'devices.capabilities.dynamic_scene' && !capabilityHasSceneOptions(capability))) {
+            try {
+              const sceneCapabilities = await this.getScenes(device.sku, device.device)
+              capabilities = mergeSceneCapabilities(capabilities, sceneCapabilities)
+            } catch (err) {
+              this.log.debug?.(`[OPENAPI] could not fetch scenes for ${device.device}: ${parseError(err)}`)
+            }
+          }
+
+          const byInstance = capabilityLookup(capabilities)
+          const colorTempRange = findRange(byInstance.colorTemperatureK)
+          const brightnessRange = findRange(byInstance.brightness)
+          const properties = {}
+          const supportCmds = []
+
+          if (byInstance.powerSwitch) {
+            supportCmds.push('turn')
+          }
+
+          if (brightnessRange) {
+            supportCmds.push('bright')
+            properties.bright = { range: brightnessRange }
+          }
+
+          if (byInstance.colorRgb) {
+            supportCmds.push('colour')
+          }
+
+          if (colorTempRange) {
+            supportCmds.push('colorTem')
+            properties.colorTem = { range: colorTempRange }
+          }
+
+          return {
+            device: device.device,
+            deviceName: device.deviceName || device.name || device.device,
+            model: device.sku,
+            openApiInfo: {
+              capabilities,
+              byInstance,
+              category: device.category || device.type || null,
+              image: device.skuUrl || null,
+            },
+            properties,
+            supportCmds,
+          }
+        }),
+    )
+
+    return parsedDevices
+  }
+
+  async requestUpdate(accessory) {
+    const state = await this.getState(accessory.context.gvModel, accessory.context.gvDeviceId)
+    this.platform.receiveUpdateOpenAPI(accessory.context.gvDeviceId, state)
+  }
+
+  async getState(sku, device) {
+    const data = await this.request({
+      method: 'post',
+      path: '/router/api/v1/device/state',
+      data: {
+        requestId: `hb-state-${Date.now()}`,
+        payload: { sku, device },
+      },
+    })
+
+    const capabilities = getCapabilitiesFromPayload(data)
+    const normalized = {}
+
+    capabilities.forEach((capability) => {
+      const value = getCapabilityValue(capability)
+      switch (capability?.instance) {
+        case 'online':
+          normalized.online = !!value
+          break
+        case 'powerSwitch':
+          normalized.onOff = Number(value)
+          break
+        case 'brightness':
+          normalized.brightness = Number(value)
+          break
+        case 'colorRgb': {
+          const rgb = intToRgb(value)
+          if (rgb) {
+            normalized.color = rgb
+          }
+          break
+        }
+        case 'colorTemperatureK':
+          normalized.colorTemInKelvin = Number(value)
+          break
+        default:
+          break
+      }
+    })
+
+    return normalized
+  }
+
+  getCapability(accessory, instance, fallbackType) {
+    const lookup = accessory.context.openApiCapabilities || {}
+    const capability = lookup[instance]
+    if (capability?.type && capability?.instance) {
+      return capability
+    }
+    return {
+      type: fallbackType,
+      instance,
+      parameters: {},
+    }
+  }
+
+  buildCapabilityPayload(accessory, params) {
+    let capability
+
+    switch (params.cmd) {
+      case 'state': {
+        const base = this.getCapability(accessory, 'powerSwitch', 'devices.capabilities.on_off')
+        capability = {
+          type: base.type,
+          instance: base.instance,
+          value: params.value === 'on' ? 1 : 0,
+        }
+        break
+      }
+      case 'brightness': {
+        const base = this.getCapability(accessory, 'brightness', 'devices.capabilities.range')
+        capability = {
+          type: base.type,
+          instance: base.instance,
+          value: validateRangeValue(base, params.value, params.cmd),
+        }
+        break
+      }
+      case 'color': {
+        const base = this.getCapability(accessory, 'colorRgb', 'devices.capabilities.color_setting')
+        capability = {
+          type: base.type,
+          instance: base.instance,
+          value: (params.value.r << 16) + (params.value.g << 8) + params.value.b,
+        }
+        break
+      }
+      case 'colorTem': {
+        const base = this.getCapability(accessory, 'colorTemperatureK', 'devices.capabilities.color_setting')
+        capability = {
+          type: base.type,
+          instance: base.instance,
+          value: validateRangeValue(base, params.value, params.cmd),
+        }
+        break
+      }
+      case 'lightScene':
+      case 'diyScene':
+      case 'scene': {
+        const instance = params.instance || (params.cmd === 'diyScene' ? 'diyScene' : 'lightScene')
+        const base = this.getCapability(accessory, instance, 'devices.capabilities.dynamic_scene')
+        let value = params.value
+
+        if (typeof value === 'string') {
+          const matched = findOptionByName(base, value)
+          if (!matched) {
+            throw new Error(`scene not available via OpenAPI [${value}]`)
+          }
+          value = matched.value
+        }
+
+        capability = {
+          type: base.type,
+          instance: base.instance,
+          value,
+        }
+        break
+      }
+      default:
+        throw new Error(`command not supported via OpenAPI [${params.cmd}]`)
+    }
+
+    return capability
+  }
+
+  async updateDevice(accessory, params) {
+    const capability = this.buildCapabilityPayload(accessory, params)
+
+    await this.request({
+      method: 'post',
+      path: '/router/api/v1/device/control',
+      data: {
+        requestId: `hb-control-${Date.now()}`,
+        payload: {
+          sku: accessory.context.gvModel,
+          device: accessory.context.gvDeviceId,
+          capability,
+        },
+      },
+    })
+  }
+}

--- a/lib/connection/openapi.js
+++ b/lib/connection/openapi.js
@@ -1,5 +1,6 @@
 import axios from 'axios'
 
+import { k2rgb } from '../utils/colour.js'
 import { parseError } from '../utils/functions.js'
 
 const BASE_URL = 'https://openapi.api.govee.com'
@@ -43,6 +44,31 @@ function intToRgb(value) {
     g: (rgb >> 8) & 0xFF,
     b: rgb & 0xFF,
   }
+}
+
+function rgbDistance(a, b) {
+  if (!a || !b) {
+    return Number.POSITIVE_INFINITY
+  }
+  return Math.abs(a.r - b[0]) + Math.abs(a.g - b[1]) + Math.abs(a.b - b[2])
+}
+
+function inferKelvinFromRgb(rgb) {
+  let bestKelvin = null
+  let bestDistance = Number.POSITIVE_INFINITY
+
+  for (let kelvin = 2000; kelvin <= 7100; kelvin += 100) {
+    const candidate = k2rgb(kelvin)
+    const distance = rgbDistance(rgb, candidate)
+    if (distance < bestDistance) {
+      bestDistance = distance
+      bestKelvin = kelvin
+    }
+  }
+
+  // Only treat RGB as white temperature if it is very close to one of the known
+  // Kelvin RGB values. This avoids reclassifying obvious colors like red/blue.
+  return bestDistance <= 40 ? bestKelvin : null
 }
 
 function getDevicesFromPayload(data) {
@@ -269,6 +295,8 @@ export default class {
 
     const capabilities = getCapabilitiesFromPayload(data)
     const normalized = {}
+    let colorRgb = null
+    let colorTemInKelvin = null
 
     capabilities.forEach((capability) => {
       const value = getCapabilityValue(capability)
@@ -285,17 +313,41 @@ export default class {
         case 'colorRgb': {
           const rgb = intToRgb(value)
           if (rgb) {
-            normalized.color = rgb
+            colorRgb = rgb
           }
           break
         }
         case 'colorTemperatureK':
-          normalized.colorTemInKelvin = Number(value)
+          colorTemInKelvin = Number(value)
           break
         default:
           break
       }
     })
+
+    if (Number.isFinite(colorTemInKelvin) && colorTemInKelvin > 0) {
+      normalized.colorTemInKelvin = colorTemInKelvin
+    }
+
+    if (colorRgb) {
+      if (Number.isFinite(colorTemInKelvin) && colorTemInKelvin > 0) {
+        const kelvinRgb = k2rgb(colorTemInKelvin)
+
+        // OpenAPI reports both RGB and Kelvin even in white mode, so only treat RGB as active
+        // when it differs materially from the RGB equivalent of the reported Kelvin.
+        if (rgbDistance(colorRgb, kelvinRgb) > 30) {
+          normalized.color = colorRgb
+          delete normalized.colorTemInKelvin
+        }
+      } else {
+        const inferredKelvin = inferKelvinFromRgb(colorRgb)
+        if (inferredKelvin) {
+          normalized.colorTemInKelvin = inferredKelvin
+        } else {
+          normalized.color = colorRgb
+        }
+      }
+    }
 
     return normalized
   }

--- a/lib/homebridge-ui/public/index.html
+++ b/lib/homebridge-ui/public/index.html
@@ -44,7 +44,7 @@
 <div id="pageIntro" class="text-center" style="display: none;">
   <p class="lead">Thank you for installing <strong>homebridge-govee</strong></p>
   <p>
-    You will need your Govee email & password to continue - this plugin does not need a Govee API key
+    Enter your Govee credentials or a Govee OpenAPI key in the plugin Settings tab to continue. The OpenAPI key is optional and can be used for OpenAPI discovery, state, and control where supported.
   </p>
   <button type="button" class="btn btn-primary" id="introContinue">Continue &rarr;</button>
 </div>

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -10,6 +10,7 @@ import PQueue from 'p-queue'
 import awsClient from './connection/aws.js'
 import httpClient from './connection/http.js'
 import lanClient from './connection/lan.js'
+import openApiClient from './connection/openapi.js'
 import deviceTypes from './device/index.js'
 import eveService from './fakegato/fakegato-history.js'
 import { k2rgb } from './utils/colour.js'
@@ -36,6 +37,7 @@ const awsDevices = []
 const awsDevicesToPoll = []
 const httpDevices = []
 const lanDevices = []
+const openApiDevices = []
 
 export default class {
   constructor(log, config, api) {
@@ -82,6 +84,7 @@ export default class {
       this.bleClient = false
       this.httpClient = false
       this.lanClient = false
+      this.openApiClient = false
 
       // Set up the Homebridge events
       this.api.on('didFinishLaunching', () => this.pluginSetup())
@@ -321,6 +324,7 @@ export default class {
         case 'name':
         case 'platform':
           break
+        case 'apiKey':
         case 'password':
         case 'username':
           if (typeof val !== 'string' || val === '') {
@@ -396,6 +400,22 @@ export default class {
         Object.keys(this.deviceConf).forEach((id) => {
           delete this.deviceConf[id].customIPAddress
         })
+      }
+
+      // Set up the HTTP client if Govee username and password have been provided
+      try {
+        if (!this.config.apiKey) {
+          throw new Error(platformLang.openApiNoKey)
+        }
+        this.openApiClient = new openApiClient(this)
+        const devices = await this.openApiClient.getDevices()
+        devices.forEach(device => openApiDevices.push(device))
+        this.log('[OPENAPI] %s.', platformLang.availableWithDevices(devices.length))
+      } catch (err) {
+        this.log.warn('[OPENAPI] %s %s.', platformLang.disableClient, parseError(err, [
+          platformLang.openApiNoKey,
+        ]))
+        this.openApiClient = false
       }
 
       // Set up the HTTP client if Govee username and password have been provided
@@ -561,6 +581,7 @@ export default class {
       let httpSyncNeeded = false
       let lanDevicesWereInitialised = false
       let httpDevicesWereInitialised = false
+      let openApiDevicesWereInitialised = false
 
       if (httpDevices && httpDevices.length > 0) {
         // We have some devices from HTTP client
@@ -619,6 +640,42 @@ export default class {
         })
       }
 
+      if (openApiDevices && openApiDevices.length > 0) {
+        openApiDevices.forEach((openApiDevice) => {
+          if (this.ignoredDevices.includes(openApiDevice.device)) {
+            return
+          }
+
+          if (platformConsts.matterModels.includes(openApiDevice.model) && this.config.ignoreMatter) {
+            return
+          }
+
+          if (httpDevices.some(httpDevice => httpDevice.device === openApiDevice.device)) {
+            return
+          }
+
+          const lanDevice = lanDevices.find(el => el.device === openApiDevice.device)
+
+          if (lanDevice) {
+            this.initialiseDevice({
+              ...lanDevice,
+              deviceName: openApiDevice.deviceName,
+              model: openApiDevice.model,
+              openApiInfo: openApiDevice.openApiInfo,
+              properties: openApiDevice.properties,
+              supportCmds: openApiDevice.supportCmds,
+              isLanDevice: true,
+            })
+            lanDevicesWereInitialised = true
+            lanDevice.initialised = true
+          } else {
+            this.initialiseDevice(openApiDevice)
+          }
+
+          openApiDevicesWereInitialised = true
+        })
+      }
+
       // Some LAN devices may exist outside the HTTP client
       const pendingLANDevices = lanDevices.filter(el => !el.initialised)
       if (pendingLANDevices.length > 0) {
@@ -642,7 +699,7 @@ export default class {
         })
       }
 
-      if (!lanDevicesWereInitialised && !httpDevicesWereInitialised) {
+      if (!lanDevicesWereInitialised && !httpDevicesWereInitialised && !openApiDevicesWereInitialised) {
         // No devices either from HTTP client nor LAN client
         throw new Error(platformLang.noDevs)
       }
@@ -651,7 +708,9 @@ export default class {
       devicesInHB.forEach((accessory) => {
         // If the accessory doesn't exist in Govee then remove it
         if (
-          (!httpDevices.some(el => el.device === accessory.context.gvDeviceId) && !lanDevices.some(el => el.device === accessory.context.gvDeviceId))
+          (!httpDevices.some(el => el.device === accessory.context.gvDeviceId)
+            && !lanDevices.some(el => el.device === accessory.context.gvDeviceId)
+            && !openApiDevices.some(el => el.device === accessory.context.gvDeviceId))
           || this.ignoredDevices.includes(accessory.context.gvDeviceId)
         ) {
           this.removeAccessory(accessory)
@@ -685,6 +744,14 @@ export default class {
         this.goveeHTTPSync()
         this.refreshHTTPInterval = setInterval(
           () => this.goveeHTTPSync(),
+          this.config.httpRefreshTime * 1000,
+        )
+      }
+
+      if (this.openApiClient && openApiDevicesWereInitialised) {
+        this.goveeOpenApiSync()
+        this.refreshOpenApiInterval = setInterval(
+          () => this.goveeOpenApiSync(),
           this.config.httpRefreshTime * 1000,
         )
       }
@@ -774,14 +841,20 @@ export default class {
         this.httpClient.logout()
         this.log('[HTTP] logged out from session.')
       }
+      if (this.refreshOpenApiInterval) {
+        clearInterval(this.refreshOpenApiInterval)
+        this.log('[OPENAPI] refresh interval stopped.')
+      }
       if (this.refreshAWSInterval) {
         clearInterval(this.refreshAWSInterval)
         this.log('[AWS] refresh interval stopped.')
       }
 
       // Close the LAN client
-      this.lanClient.close()
-      this.log('[LAN] client closed.')
+      if (this.lanClient?.close) {
+        this.lanClient.close()
+        this.log('[LAN] client closed.')
+      }
 
       // Stop BLE operations immediately if the BLE client is running
       if (this.bleClient) {
@@ -1047,6 +1120,8 @@ export default class {
       // Add some initial context information which is changed later
       accessory.context.hasAwsControl = false
       accessory.context.useAwsControl = false
+      accessory.context.hasOpenApiControl = false
+      accessory.context.useOpenApiControl = false
       accessory.context.hasBleControl = false
       accessory.context.useBleControl = false
       accessory.context.hasLanControl = device.isLanDevice
@@ -1134,6 +1209,12 @@ export default class {
             }
           }
         }
+      }
+
+      if (device.openApiInfo) {
+        accessory.context.hasOpenApiControl = true
+        accessory.context.useOpenApiControl = !!this.openApiClient
+        accessory.context.openApiCapabilities = device.openApiInfo.byInstance || {}
       }
 
       // Create the instance for this device type
@@ -1304,6 +1385,24 @@ export default class {
     }
   }
 
+  async goveeOpenApiSync() {
+    try {
+      for (const device of openApiDevices) {
+        const accessory = devicesInHB.get(this.api.hap.uuid.generate(device.device))
+        if (!accessory?.context?.useOpenApiControl) {
+          continue
+        }
+        try {
+          await this.openApiClient.requestUpdate(accessory)
+        } catch (err) {
+          accessory.logDebugWarn(`[OPENAPI] ${platformLang.syncFail} ${parseError(err)}`)
+        }
+      }
+    } catch (err) {
+      this.log.warn('[OPENAPI] %s %s.', platformLang.syncFail, parseError(err))
+    }
+  }
+
   addAccessory(device) {
     // Add an accessory to Homebridge
     try {
@@ -1414,6 +1513,10 @@ export default class {
           cmd: 'turn',
           data: { value: params.value === 'on' ? 1 : 0 },
         }
+        data.openApiParams = {
+          cmd: 'state',
+          value: params.value,
+        }
         break
       }
       case 'stateDual': {
@@ -1502,6 +1605,10 @@ export default class {
             value: params.value,
           },
         }
+        data.openApiParams = {
+          cmd: 'brightness',
+          value: params.value,
+        }
         break
       }
       case 'color': {
@@ -1588,6 +1695,10 @@ export default class {
             colorTemInKelvin: 0,
           },
         }
+        data.openApiParams = {
+          cmd: 'color',
+          value: params.value,
+        }
         break
       }
       case 'colorTem': {
@@ -1668,6 +1779,10 @@ export default class {
             colorTemInKelvin: params.value,
           },
         }
+        data.openApiParams = {
+          cmd: 'colorTem',
+          value: params.value,
+        }
         break
       }
       case 'rgbScene': {
@@ -1711,6 +1826,15 @@ export default class {
         return true
       } catch (err) {
         accessory.logWarn(`${platformLang.notLANSent} ${parseError(err, [platformLang.lanDevNotFound])}`)
+      }
+    }
+
+    if (accessory.context.useOpenApiControl && data.openApiParams) {
+      try {
+        await this.openApiClient.updateDevice(accessory, data.openApiParams)
+        return true
+      } catch (err) {
+        accessory.logWarn(`[OPENAPI] ${platformLang.devNotUpdated} ${parseError(err)}`)
       }
     }
 
@@ -1790,6 +1914,17 @@ export default class {
     })
   }
 
+  receiveUpdateOpenAPI(accessoryId, params) {
+    devicesInHB.forEach((accessory) => {
+      if (accessory.context.gvDeviceId === accessoryId) {
+        this.receiveDeviceUpdate(accessory, {
+          source: 'OPENAPI',
+          state: params,
+        })
+      }
+    })
+  }
+
   receiveUpdateAWS(payload) {
     const accessoryUUID = this.api.hap.uuid.generate(payload.device)
     const accessory = devicesInHB.get(accessoryUUID)
@@ -1850,7 +1985,7 @@ export default class {
       BRIGHTNESS
     */
     if (params.state && hasProperty(params.state, 'brightness')) {
-      if (params.source === 'LAN') {
+      if (params.source !== 'AWS') {
         data.brightness = params.state.brightness
       } else if (params.source === 'AWS') {
         data.brightness = accessory.context.awsBrightnessNoScale

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -1,6 +1,7 @@
 export default {
   defaultConfig: {
     name: 'Govee',
+    apiKey: '',
     username: '',
     password: '',
     ignoreMatter: false,

--- a/lib/utils/lang-en.js
+++ b/lib/utils/lang-en.js
@@ -16,6 +16,7 @@ export default {
   awsEventReconnect: 'reconnect event',
   available: 'client enabled',
   availableWithDevices: n => `client enabled and found ${n} device(s)`,
+  openApiNoKey: 'api key not provided',
   brand: 'Govee',
   bleNonControl: 'will be visible but uncontrollable as BLE not available',
   bleNoPackage: 'required hardware/packages not available',


### PR DESCRIPTION
  ## :recycle: Current situation

  The plugin currently relies on AWS, LAN, and BLE connection paths, but it does not have a usable OpenAPI-based path even though Govee provides documented OpenAPI endpoints for:

  - device discovery
  - device state reads
  - device control
  - dynamic scene lookup

  A related config/UI issue is that the plugin settings currently do not expose any way to enter an OpenAPI key. The existing README/custom UI copy also states that the plugin does not use
  the Govee API key, which no longer matches the intended behavior of this change.

  In practice, this means users whose devices are accessible through Govee OpenAPI cannot use that connection method in the plugin today, and there is no fallback when cloud app login/AWS
  flows fail for their account or model.

  ## :bulb: Proposed solution

  This PR adds an OpenAPI connection path and exposes an API key field in the plugin settings.

  Main changes:

  - add `lib/connection/openapi.js`
    - discover devices via `GET /router/api/v1/user/devices`
    - read device state via `POST /router/api/v1/device/state`
    - control devices via `POST /router/api/v1/device/control`
    - fetch dynamic scene options via `POST /router/api/v1/device/scenes`
  - integrate OpenAPI into `lib/platform.js` as an additional connection method rather than replacing LAN/AWS/BLE
  - add `apiKey` to `config.schema.json`
  - fix the schema `layout` so the `apiKey` field is actually rendered in `Required Settings`
  - update the custom UI intro text so it no longer says the plugin does not use an API key
  - update README wording to reflect OpenAPI support

  Implementation notes:

  - capability handling is driven by the OpenAPI response metadata (`type`, `instance`, ranges, options) rather than hardcoded to specific device IDs
  - state normalization now handles OpenAPI responses that return values under `capability.state.value`
  - dynamic scene data is merged from the documented scenes endpoint when discovery does not include scene options
  - this change is intended to be device-agnostic for any user whose API key can see supported devices through OpenAPI

  ## :gear: Release Notes

  Adds support for configuring a `Govee OpenAPI Key` in the Homebridge UI and uses that key for OpenAPI-based device discovery, state refresh, and control where supported.

  Users can now:

  - enter a Govee OpenAPI key in plugin settings
  - discover devices available through Govee OpenAPI
  - read device state through OpenAPI
  - control supported devices through OpenAPI
  - retrieve dynamic scene capability metadata for supported devices

  No breaking config migration is intended. Existing LAN/AWS/BLE behavior remains in place, and OpenAPI is added as an additional connection option.

  ## :heavy_plus_sign: Additional Information

  This change was implemented against Govee's documented OpenAPI behavior for:

  - device discovery
  - device state
  - device control
  - dynamic scenes

  I intentionally did not include MQTT event subscription from the OpenAPI docs in this PR, since that would introduce additional runtime behavior/dependencies and should likely be reviewed
  separately.

  Known limitations in this PR:

  - `SameModeGroup`/group devices are still not mapped to supported accessory types
  - OpenAPI MQTT event subscription is not implemented here
  - scene control plumbing is prepared in the OpenAPI layer, but this PR is primarily focused on discovery/state/control and API key config support

  ### Testing

  Functional testing was done locally with Homebridge in Docker against real Govee OpenAPI responses:

  - verified device discovery through `/router/api/v1/user/devices`
  - verified state polling through `/router/api/v1/device/state`
  - verified initialization of discovered light accessories
  - verified the schema/layout fix so the `Govee OpenAPI Key` field is included in `Required Settings`

  No automated unit/regression tests were added in this PR.

  I also attempted to run the repo lint step, but the local environment used for this work was running Node `18.19.1` while the current repo/tooling targets Node `20/22/24`, so ESLint could
  not be executed successfully in that environment.

  ### Reviewer Nudging

  A good review path is:

  1. `config.schema.json`
     - check the new `apiKey` field
     - check the `layout` fix that makes the field visible in the UI
  2. `lib/connection/openapi.js`
     - review the OpenAPI request/response handling
     - review capability normalization and dynamic scene fetching
  3. `lib/platform.js`
     - review how OpenAPI is integrated into setup, refresh, and outgoing control flow
  4. `README.md` and `lib/homebridge-ui/public/index.html`
     - review the minimal documentation/UI wording updates