### PR TITLE
fix: OpenAPI lights no longer classified as BLE-only

### DIFF
--- a/lib/device/light.js
+++ b/lib/device/light.js
@@ -27,7 +27,7 @@ export default class {
     this.colourSafeMode = platform.config.colourSafeMode
     this.minKelvin = accessory.context?.supportedCmdsOpts?.colorTem?.range?.min || 2000
     this.maxKelvin = accessory.context?.supportedCmdsOpts?.colorTem?.range?.max || 9000
-    this.isBLEOnly = !accessory.context.useAwsControl && !accessory.context.useLanControl
+    this.isBLEOnly = !accessory.context.useAwsControl && !accessory.context.useLanControl && !accessory.context.useOpenApiControl
 
     // Set up custom variables for this device type
     const deviceConf = platform.deviceConf[accessory.context.gvDeviceId] || {}


### PR DESCRIPTION
Fixes BLE-only logic to classify OpenAPI devices as not BLE-only

## :recycle: Current situation

When initializing a light device, the `isBLEOnly` variable is set based on only if AWS and LAN control are both disabled. Devices that use only OpenAPI control and do not use AWS or LAN control are therefore considered as BLE-only devices.

## :bulb: Proposed solution

Add condition checking that OpenAPI control is also disabled.

## :gear: Release Notes

Fixed OpenAPI devices missing color temperature control.

### Testing

Tested with H6008 lights under OpenAPI control. Color updates via color temperature correctly. "Adaptive lighting disabled due to significant color change" issue is still present, but that is because all APIs don't report the actual minimum and maximum temperatures of 2700K and 6500K, respectively (APIs report 2000K to 9000K for range).