### PR TITLE
fix: do not treat lights controllable via the openapi as bluetooth only

### DIFF
--- a/lib/device/light.js
+++ b/lib/device/light.js
@@ -27,7 +27,7 @@ export default class {
     this.colourSafeMode = platform.config.colourSafeMode
     this.minKelvin = accessory.context?.supportedCmdsOpts?.colorTem?.range?.min || 2000
     this.maxKelvin = accessory.context?.supportedCmdsOpts?.colorTem?.range?.max || 9000
-    this.isBLEOnly = !accessory.context.useAwsControl && !accessory.context.useLanControl
+    this.isBLEOnly = !accessory.context.useAwsControl && !accessory.context.useLanControl && !accessory.context.useOpenApiControl
 
     // Set up custom variables for this device type
     const deviceConf = platform.deviceConf[accessory.context.gvDeviceId] || {}


### PR DESCRIPTION
## Problem

Govee's main login API (`app2.govee.com/account/rest/account/v2/login`) returns status `454` for accounts logging in from unrecognized devices. The current code handles this by triggering an email verification code and throwing `twoFARequired`, which requires users to manually add a `code` to their config and restart Homebridge.

In practice, the verification email often does not arrive, leaving users completely locked out with no fallback.

## Solution

When the main login returns `454`, automatically retry using the Govee community API (`community-api.govee.com/os/v1/login`), which does not enforce device verification. Tokens issued by the community API are accepted by all `app2.govee.com` endpoints, including device list, IoT key, and leak warning endpoints.

The existing email verification code flow is preserved as a secondary fallback if the community API also fails.

## Changes

- Added `communityLogin()` method that authenticates via the community API and fetches IoT credentials
- Modified the `454` handler in `login()` to try `communityLogin()` first before falling back to the email verification flow

## Testing

Verified on macOS with Homebridge v1.11.4 and four H5058 water leak sensors. The community token successfully authenticates against:
- `app2.govee.com/bff-app/v1/device/list` — returns all devices
- `app2.govee.com/app/v1/account/iot/key` — returns IoT credentials
- `app2.govee.com/leak/rest/device/v1/warnMessage` — returns leak sensor state

All four sensors appear in HomeKit with correct battery levels and leak status.

## Notes

The `topic` field returned by `communityLogin()` uses the pattern `GA/${accountId}` since the community API does not return the MQTT topic. This works for sensor/polling-based devices. For devices relying on AWS real-time control, the main login path remains preferred when it works.