### PR TITLE
feat: add support for Floor Lamp H16B0 and Table Lamp H1741

### DIFF
--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -129,6 +129,8 @@ export default {
   models: {
     rgb: [
       'H1401',
+      'H16B0', // https://github.com/homebridge-plugins/homebridge-govee/issues/1278
+      'H1741', // https://github.com/homebridge-plugins/homebridge-govee/issues/1278
       'H6001',
       'H6002',
       'H6003',


### PR DESCRIPTION
Closes #1278

## What

Adds two RGB light models to `lib/utils/constants.js`:

- **H16B0** — Floor Lamp (color temp range 1000–10000K, segmented lighting, scenes, music mode)
- **H1741** — Table Lamp (color temp range 2700–6500K, 70+ scenes, music mode)

Both report standard RGB capabilities (`turn`, `bright`, `colour`, `colorTem`) via the OpenAPI, so adding them to `models.rgb` is sufficient for the existing `deviceLight` handler to instantiate them. No protocol quirks needed in `device-capabilities.js`.

## Verification

Tested end-to-end on real hardware against plugin v11.22.0 + this patch:

```
[Govee] [OPENAPI] client enabled and found 2 device(s).
[Govee] [Table Lamp] has been added to Homebridge.
[Govee] [Table Lamp] initialised with id [<redacted>] [H1741].
[Govee] [Floor Lamp] has been added to Homebridge.
[Govee] [Floor Lamp] initialised with id [<redacted>] [H16B0].
[Govee] [OPENAPI MQTT] connected and subscribed
[Govee] ✓ Setup complete.
[Govee] [Table Lamp] current brightness [100%].
[Govee] [Floor Lamp] current state [on]. brightness [90%].
```

Both lamps now appear and respond in HomeKit. Confirmed that `light.js:28-29` reads the per-device color-temp range from `accessory.context.supportedCmdsOpts.colorTem.range`, so the H16B0's unusual 1000–10000K range is handled correctly without any hardcoded clipping.

## Caveats

Only OpenAPI was tested (LAN is unsupported for these models in my setup, and BLE wasn't exercised). If a future BLE-only user reports issues, a per-model entry in `device-capabilities.js` may be needed — but that's a follow-up if/when reported.

Lint passes (`eslint . --max-warnings=0`).