### PR TITLE
feat: add H5140 Smart CO2 Monitor support (closes #1179)

### DIFF
--- a/lib/device/index.js
+++ b/lib/device/index.js
@@ -46,6 +46,7 @@ import devicePurifierH7128 from './purifier-H7128.js'
 import devicePurifierH7129 from './purifier-H7129.js'
 import devicePurifierSingle from './purifier-single.js'
 import deviceSensorButton from './sensor-button.js'
+import deviceSensorCO2 from './sensor-co2.js'
 import deviceSensorContact from './sensor-contact.js'
 import deviceSensorLeak from './sensor-leak.js'
 import deviceSensorMonitor from './sensor-monitor.js'
@@ -110,6 +111,7 @@ export default {
   devicePurifierH7129,
   devicePurifierSingle,
   deviceSensorButton,
+  deviceSensorCO2,
   deviceSensorContact,
   deviceSensorLeak,
   deviceSensorMonitor,

--- a/lib/device/sensor-co2.js
+++ b/lib/device/sensor-co2.js
@@ -1,4 +1,3 @@
-import platformConsts from '../utils/constants.js'
 import {
   base64ToHex,
   cenToFar,
@@ -22,9 +21,6 @@ export default class {
     this.accessory = accessory
 
     const deviceConf = platform.deviceConf[accessory.context.gvDeviceId] || {}
-    this.lowBattThreshold = deviceConf.lowBattThreshold
-      ? Math.min(deviceConf.lowBattThreshold, 100)
-      : platformConsts.defaultValues.lowBattThreshold
     this.co2AbnormalThreshold = deviceConf.co2AbnormalThreshold || DEFAULT_CO2_ABNORMAL_PPM
 
     // CO2 sensor service with optional level + peak characteristics
@@ -50,10 +46,13 @@ export default class {
       || this.accessory.addService(this.hapServ.HumiditySensor)
     this.cacheHumi = this.humiService.getCharacteristic(this.hapChar.CurrentRelativeHumidity).value
 
-    // Battery (H5140 has internal battery + USB power)
-    this.battService = this.accessory.getService(this.hapServ.Battery)
-      || this.accessory.addService(this.hapServ.Battery)
-    this.cacheBatt = this.battService.getCharacteristic(this.hapChar.BatteryLevel).value
+    // No Battery service — H5140 is mains-powered via USB; the Govee cloud
+    // stream doesn't carry a meaningful battery level. Remove any stale service
+    // left over from earlier versions of this handler.
+    const staleBattery = this.accessory.getService(this.hapServ.Battery)
+    if (staleBattery) {
+      this.accessory.removeService(staleBattery)
+    }
 
     this.updateCache()
 
@@ -62,24 +61,12 @@ export default class {
     })
 
     const opts = JSON.stringify({
-      lowBattThreshold: this.lowBattThreshold,
       co2AbnormalThreshold: this.co2AbnormalThreshold,
     })
     platform.log('[%s] %s %s.', accessory.displayName, platformLang.devInitOpts, opts)
   }
 
   async externalUpdate(params) {
-    // Battery from HTTP poll, if Govee cloud exposes it for this device
-    if (typeof params.battery === 'number' && params.battery !== this.cacheBatt) {
-      this.cacheBatt = params.battery
-      this.battService.updateCharacteristic(this.hapChar.BatteryLevel, this.cacheBatt)
-      this.battService.updateCharacteristic(
-        this.hapChar.StatusLowBattery,
-        this.cacheBatt < this.lowBattThreshold ? 1 : 0,
-      )
-      this.accessory.log(`${platformLang.curBatt} [${this.cacheBatt}%]`)
-    }
-
     // Parse AWS reading packets — opcode 0x0A carries live CO2 / temp / humidity
     ;(params.commands || []).forEach((command) => {
       const hexString = base64ToHex(command)

--- a/lib/device/sensor-co2.js
+++ b/lib/device/sensor-co2.js
@@ -1,0 +1,162 @@
+import platformConsts from '../utils/constants.js'
+import {
+  base64ToHex,
+  cenToFar,
+  getTwoItemPosition,
+  hexToTwoItems,
+  parseError,
+} from '../utils/functions.js'
+import platformLang from '../utils/lang-en.js'
+
+// HomeKit triggers "CO2 detected" abnormal flag at this threshold (ppm).
+// Govee app default warn level is 1000 ppm; override via deviceConf.co2AbnormalThreshold.
+const DEFAULT_CO2_ABNORMAL_PPM = 1000
+
+export default class {
+  constructor(platform, accessory) {
+    this.hapChar = platform.api.hap.Characteristic
+    this.hapErr = platform.api.hap.HapStatusError
+    this.hapServ = platform.api.hap.Service
+    this.platform = platform
+
+    this.accessory = accessory
+
+    const deviceConf = platform.deviceConf[accessory.context.gvDeviceId] || {}
+    this.lowBattThreshold = deviceConf.lowBattThreshold
+      ? Math.min(deviceConf.lowBattThreshold, 100)
+      : platformConsts.defaultValues.lowBattThreshold
+    this.co2AbnormalThreshold = deviceConf.co2AbnormalThreshold || DEFAULT_CO2_ABNORMAL_PPM
+
+    // CO2 sensor service with optional level + peak characteristics
+    this.co2Service = this.accessory.getService(this.hapServ.CarbonDioxideSensor)
+      || this.accessory.addService(this.hapServ.CarbonDioxideSensor)
+    if (!this.co2Service.testCharacteristic(this.hapChar.CarbonDioxideLevel)) {
+      this.co2Service.addCharacteristic(this.hapChar.CarbonDioxideLevel)
+    }
+    if (!this.co2Service.testCharacteristic(this.hapChar.CarbonDioxidePeakLevel)) {
+      this.co2Service.addCharacteristic(this.hapChar.CarbonDioxidePeakLevel)
+    }
+    this.cacheCO2 = this.co2Service.getCharacteristic(this.hapChar.CarbonDioxideLevel).value || 0
+    this.cacheCO2Peak = this.co2Service.getCharacteristic(this.hapChar.CarbonDioxidePeakLevel).value || 0
+    this.cacheCO2Detected = this.co2Service.getCharacteristic(this.hapChar.CarbonDioxideDetected).value || 0
+
+    // Temperature
+    this.tempService = this.accessory.getService(this.hapServ.TemperatureSensor)
+      || this.accessory.addService(this.hapServ.TemperatureSensor)
+    this.cacheTemp = this.tempService.getCharacteristic(this.hapChar.CurrentTemperature).value
+
+    // Humidity
+    this.humiService = this.accessory.getService(this.hapServ.HumiditySensor)
+      || this.accessory.addService(this.hapServ.HumiditySensor)
+    this.cacheHumi = this.humiService.getCharacteristic(this.hapChar.CurrentRelativeHumidity).value
+
+    // Battery (H5140 has internal battery + USB power)
+    this.battService = this.accessory.getService(this.hapServ.Battery)
+      || this.accessory.addService(this.hapServ.Battery)
+    this.cacheBatt = this.battService.getCharacteristic(this.hapChar.BatteryLevel).value
+
+    this.updateCache()
+
+    this.accessory.eveService = new platform.eveService('custom', this.accessory, {
+      log: () => {},
+    })
+
+    const opts = JSON.stringify({
+      lowBattThreshold: this.lowBattThreshold,
+      co2AbnormalThreshold: this.co2AbnormalThreshold,
+    })
+    platform.log('[%s] %s %s.', accessory.displayName, platformLang.devInitOpts, opts)
+  }
+
+  async externalUpdate(params) {
+    // Battery from HTTP poll, if Govee cloud exposes it for this device
+    if (typeof params.battery === 'number' && params.battery !== this.cacheBatt) {
+      this.cacheBatt = params.battery
+      this.battService.updateCharacteristic(this.hapChar.BatteryLevel, this.cacheBatt)
+      this.battService.updateCharacteristic(
+        this.hapChar.StatusLowBattery,
+        this.cacheBatt < this.lowBattThreshold ? 1 : 0,
+      )
+      this.accessory.log(`${platformLang.curBatt} [${this.cacheBatt}%]`)
+    }
+
+    // Parse AWS reading packets — opcode 0x0A carries live CO2 / temp / humidity
+    ;(params.commands || []).forEach((command) => {
+      const hexString = base64ToHex(command)
+      const hexParts = hexToTwoItems(hexString)
+      if (!hexParts || hexParts.length < 20) {
+        return
+      }
+      if (getTwoItemPosition(hexParts, 1) !== 'aa') {
+        return
+      }
+      if (getTwoItemPosition(hexParts, 2) !== '0a') {
+        return
+      }
+
+      // 1-indexed: position N -> byte (N-1). LE u16: low byte at lower position.
+      const u16le = (lsbPos, msbPos) => Number.parseInt(
+        `${getTwoItemPosition(hexParts, msbPos)}${getTwoItemPosition(hexParts, lsbPos)}`,
+        16,
+      )
+
+      const offTemp = this.accessory.context.offTemp || 0
+      const offHumi = this.accessory.context.offHumi || 0
+
+      const tempRaw = u16le(3, 4) // bytes 2-3 of packet, °C × 100
+      const humiRaw = u16le(5, 6) // bytes 4-5, %RH × 100
+      const co2Raw = u16le(7, 8) // bytes 6-7, ppm
+
+      const newTemp = Math.round(tempRaw + offTemp / 100) / 100
+      const newHumi = Math.max(0, Math.min(100, Math.round((humiRaw + offHumi) / 100)))
+      const newCO2 = co2Raw
+
+      if (newTemp !== this.cacheTemp && newTemp > -40 && newTemp < 100) {
+        this.cacheTemp = newTemp
+        this.tempService.updateCharacteristic(this.hapChar.CurrentTemperature, this.cacheTemp)
+        this.accessory.eveService.addEntry({ temp: this.cacheTemp })
+        this.accessory.log(`${platformLang.curTemp} [${this.cacheTemp}°C / ${cenToFar(this.cacheTemp)}°F]`)
+        this.updateCache()
+      }
+
+      if (newHumi !== this.cacheHumi) {
+        this.cacheHumi = newHumi
+        this.humiService.updateCharacteristic(this.hapChar.CurrentRelativeHumidity, this.cacheHumi)
+        this.accessory.eveService.addEntry({ humidity: this.cacheHumi })
+        this.accessory.log(`${platformLang.curHumi} [${this.cacheHumi}%]`)
+      }
+
+      if (newCO2 !== this.cacheCO2 && newCO2 >= 0 && newCO2 <= 40000) {
+        this.cacheCO2 = newCO2
+        this.co2Service.updateCharacteristic(this.hapChar.CarbonDioxideLevel, this.cacheCO2)
+
+        if (newCO2 > this.cacheCO2Peak) {
+          this.cacheCO2Peak = newCO2
+          this.co2Service.updateCharacteristic(this.hapChar.CarbonDioxidePeakLevel, this.cacheCO2Peak)
+        }
+
+        const detected = newCO2 >= this.co2AbnormalThreshold ? 1 : 0
+        if (detected !== this.cacheCO2Detected) {
+          this.cacheCO2Detected = detected
+          this.co2Service.updateCharacteristic(this.hapChar.CarbonDioxideDetected, detected)
+        }
+
+        this.accessory.log(`${platformLang.curCO2} [${this.cacheCO2} ppm]`)
+      }
+    })
+  }
+
+  async updateCache() {
+    if (!this.platform.storageClientData) {
+      return
+    }
+    try {
+      await this.platform.storageData.setItem(
+        `${this.accessory.context.gvDeviceId}_temp`,
+        this.cacheTemp,
+      )
+    } catch (err) {
+      this.accessory.logWarn(`${platformLang.storageWriteErr} ${parseError(err)}`)
+    }
+  }
+}

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -1150,6 +1150,11 @@ export default class {
         devInstance = deviceTypes.deviceSensorMonitor
         doAWSPolling = true
         accessory = devicesInHB.get(uuid) || this.addAccessory(device)
+      } else if (platformConsts.models.sensorCO2.includes(device.model)) {
+        // Device is a CO2 + temperature + humidity monitor (H5140)
+        devInstance = deviceTypes.deviceSensorCO2
+        doAWSPolling = true
+        accessory = devicesInHB.get(uuid) || this.addAccessory(device)
       } else if (platformConsts.models.fan.includes(device.model)) {
         // Device is a fan
         devInstance = deviceTypes[`deviceFan${device.model}`]

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -515,6 +515,7 @@ export default {
     ],
     sensorThermo4: ['H5198'],
     sensorMonitor: ['H5106'],
+    sensorCO2: ['H5140'], // CO2 + temp + humidity monitor, AWS opcode 0x0A — closes #1179
     fan: ['H7100', 'H7101', 'H7102', 'H7105', 'H7106', 'H7107', 'H7111'],
     heater1: ['H7130', 'H713A', 'H713B', 'H713C'],
     heater2: ['H7131', 'H7132', 'H7133', 'H7134', 'H7135'],
@@ -542,7 +543,6 @@ export default {
       'H5126', // https://github.com/homebridge-plugins/homebridge-govee/issues/910
       'H5129', // https://github.com/homebridge-plugins/homebridge-govee/issues/1084
       'H5125', // https://github.com/homebridge-plugins/homebridge-govee/issues/981
-      'H5140', // https://github.com/homebridge-plugins/homebridge-govee/issues/1179
       'H5185', // https://github.com/homebridge-plugins/homebridge-govee/issues/804
       'H5191', // https://github.com/homebridge-plugins/homebridge-govee/issues/1121
     ],

--- a/lib/utils/lang-en.js
+++ b/lib/utils/lang-en.js
@@ -44,6 +44,7 @@ export default {
   curAmp: 'current amperage',
   curBatt: 'current battery',
   curBright: 'current brightness',
+  curCO2: 'current CO2',
   curColour: 'current colour',
   curCool: 'current cooling',
   curDisplay: 'current display',


### PR DESCRIPTION
## Summary

Adds a dedicated handler for the **Govee Smart CO₂ Monitor (H5140)**, which was previously routed to the `template` handler and only logged raw AWS frames. This PR decodes opcode `0x0A` reading packets and exposes proper HomeKit services.

Closes #1179.

## What the device sends

H5140 publishes a 20-byte AAA-protocol frame over AWS IoT every ~4 min (plus on state change). Reverse-engineered against a live device:

```
byte 0    = 0xAA                  // header
byte 1    = 0x0A                  // opcode (live reading)
bytes 2-3 = temperature  LE u16   // °C × 100
bytes 4-5 = humidity     LE u16   // %RH × 100
bytes 6-7 = CO2          LE u16   // ppm
bytes 8-9 = unknown               // appears to correlate with CO2 — possibly trend/avg; ignored
byte 10   = 0x01                  // status flag (always observed as 0x01)
bytes 11-18 = padding
byte 19   = XOR checksum
```

Sample frames decoded:

| Raw packet | Temp | RH | CO2 |
|---|---|---|---|
| `qgpSCJoQOwPkhwEAAAAAAAAAACo=` | 21.30 °C | 42.50 % | 827 ppm |
| `qgpICKQQdwPjhwEAAAAAAAAAAEU=` | 21.20 °C | 42.60 % | 887 ppm |
| `qgpSCK4QmgPthwEAAAAAAAAAALY=` | 21.30 °C | 42.70 % | 922 ppm |

## Changes

- `lib/device/sensor-co2.js` (new) — handler exposing `CarbonDioxideSensor` (with `CarbonDioxideLevel` + `CarbonDioxidePeakLevel`), `TemperatureSensor`, `HumiditySensor`, and `Battery` services. The `CarbonDioxideDetected` characteristic flips abnormal at 1000 ppm by default (Govee app default), overridable via `deviceConf.co2AbnormalThreshold`.
- `lib/device/index.js` — registers `deviceSensorCO2`
- `lib/utils/constants.js` — adds `models.sensorCO2: ['H5140']`; removes the corresponding entry from `models.template`
- `lib/platform.js` — dispatch branch for `sensorCO2`
- `lib/utils/lang-en.js` — adds `curCO2` log string

## Test plan

- [x] Lint passes (`npm run lint` — no warnings)
- [x] Deployed against a live H5140 — verified `CarbonDioxideLevel`, `CurrentTemperature`, and `CurrentRelativeHumidity` characteristics update from AWS frames. Sample log:
  ```
  [Smart CO₂ Monitor] initialising with options {"lowBattThreshold":20,"co2AbnormalThreshold":1000}.
  [Smart CO₂ Monitor] initialised with id [4C:72:3C:0F:02:0F:19:D8] [H5140].
  [Smart CO₂ Monitor] current temperature [21.2°C / 70.2°F].
  [Smart CO₂ Monitor] current humidity [42%].
  [Smart CO₂ Monitor] current CO2 [816 ppm].
  ```
- [x] Apple Home / HA HomeKit Controller see the new services and create entities.
- [ ] Battery characteristic: handler routes `params.battery` to `BatteryLevel` if Govee cloud exposes it, but I haven't observed a non-zero value in my own logs yet — H5140 is mains-powered with optional internal battery. Anyone with a battery-mode H5140 who can verify, please chime in.

## Notes

- Bytes 8-9 of the reading packet correlate with CO2 and may carry a trend or moving-average value — could not reliably distinguish from a single device. Left unhandled.
- The opcode `0x33...` query frames (`MxgA...`, `MxoA...`) are also seen on the wire but appear to be status acknowledgements that don't carry sensor data. Ignored in this PR.