### PR TITLE
feat: add support for Edison Bulb H14C0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `@homebridge-plugins/homebridge-govee` will be documented in this file.
 
+## v11.25.0 (Pending Release)
+
+### Changes
+
+- feat: add support for Edison Bulb H14C0 (#1301)
+
 ## v11.24.0 (2026-05-31)
 
 ### Changes

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -129,6 +129,7 @@ export default {
   models: {
     rgb: [
       'H1401',
+      'H14C0', // https://github.com/homebridge-plugins/homebridge-govee/issues/1301
       'H1630',
       'H16B0', // https://github.com/homebridge-plugins/homebridge-govee/issues/1278
       'H16C0', // https://github.com/homebridge-plugins/homebridge-govee/issues/1286
@@ -558,6 +559,7 @@ export default {
 
   matterModels: [
     'H1401',
+    'H14C0',
     'H3200',
     'H5085',
     'H600B',


### PR DESCRIPTION
Adds support for the Govee Edison Bulb (model **H14C0**).

### What
- Register `H14C0` in `models.rgb` so it routes to the generic, capability-driven light handler — on/off, brightness, RGB colour, and colour temperature (2700–6500K). No device-specific handler is required: the bulb reports the standard light capability set (`turn`, `bright`, `colour`, `colorTem`) and an AWS topic.
- Also add `H14C0` to `matterModels`, since the device advertises a `matterId`. This lets users who pair it via Matter use the `ignoreMatter` option to avoid a duplicate accessory.

### Testing
Tested live on Homebridge with two H14C0 bulbs over AWS:
- Both initialise as `[H14C0]` instead of logging "not currently supported".
- Power, brightness, RGB colour, and colour temperature all report and control correctly.

Closes #1301
