### PR TITLE
feat: add support for Ceiling Light Ultra H1270 with independent zone control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `@homebridge-plugins/homebridge-govee` will be documented in this file.
 
+## Unreleased
+
+### Changes
+
+- feat: add support for Ceiling Light Ultra H1270
+
 ## v11.24.0 (2026-05-31)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `@homebridge-plugins/homebridge-govee` will be documented
 ### Changes
 
 - feat: add support for Ceiling Light Ultra H1270
+- feat: expose independent main/background light zones for two-zone lights (e.g. H1270) as separate switches (requires OpenAPI/API key)
 
 ## v11.24.0 (2026-05-31)
 

--- a/lib/device/light.js
+++ b/lib/device/light.js
@@ -198,6 +198,33 @@ export default class {
       this.accessory.context.adaptiveLighting = true
     }
 
+    // Some lights (e.g. the H1270 Ceiling Light Ultra) have two independently
+    // controllable zones - a main/bottom panel and a background/top light. Govee
+    // exposes these as OpenAPI toggle capabilities, so add a switch for each zone
+    // the device reports. These are only controllable via the OpenAPI connection.
+    this.zoneServices = {}
+    this.zoneCache = {}
+    const zoneToggleDefs = [
+      { instance: 'mainLightToggle', name: 'Main Light' },
+      { instance: 'backgroundLightToggle', name: 'Background Light' },
+    ]
+    const openApiCaps = accessory.context.openApiCapabilities || {}
+    zoneToggleDefs.forEach(({ instance, name }) => {
+      const existingService = this.accessory.getService(name)
+      if (accessory.context.useOpenApiControl && openApiCaps[instance]) {
+        const service = existingService
+          || this.accessory.addService(this.hapServ.Switch, name, instance)
+        service
+          .getCharacteristic(this.hapChar.On)
+          .onSet(async value => this.internalZoneUpdate(instance, name, value))
+        this.zoneServices[instance] = service
+        this.zoneCache[instance] = service.getCharacteristic(this.hapChar.On).value ? 1 : 0
+      } else if (existingService) {
+        // Capability no longer available (or OpenAPI disabled) so remove the switch
+        this.accessory.removeService(existingService)
+      }
+    })
+
     // Output the customised options to the log
     const useAwsControl = accessory.context.useAwsControl ? 'enabled' : 'disabled'
     const useBleControl = accessory.context.useBleControl ? 'enabled' : 'disabled'
@@ -244,6 +271,43 @@ export default class {
       // Throw a 'no response' error and set a timeout to revert this after 2 seconds
       setTimeout(() => {
         this.service.updateCharacteristic(this.hapChar.On, this.cacheState === 'on')
+      }, 2000)
+      throw new this.hapErr(-70402)
+    }
+  }
+
+  async internalZoneUpdate(instance, name, value) {
+    const service = this.zoneServices[instance]
+    try {
+      const newValue = value ? 1 : 0
+
+      // Don't continue if the new value is the same as before
+      if (this.zoneCache[instance] === newValue) {
+        return
+      }
+
+      // These toggles are only controllable via the OpenAPI (cloud) connection
+      await this.platform.sendDeviceUpdate(this.accessory, {
+        cmd: 'openApi',
+        openApi: {
+          instance,
+          capabilityType: 'devices.capabilities.toggle',
+          value: newValue,
+        },
+      })
+
+      // Cache the new state and log
+      this.zoneCache[instance] = newValue
+      this.accessory.log(`[${name}] ${platformLang.curState} [${value ? 'on' : 'off'}]`)
+    } catch (err) {
+      // Catch any errors during the process
+      this.accessory.logWarn(`[${name}] ${platformLang.devNotUpdated} ${parseError(err)}`)
+
+      // Throw a 'no response' error and revert this after 2 seconds
+      setTimeout(() => {
+        if (service) {
+          service.updateCharacteristic(this.hapChar.On, this.zoneCache[instance] === 1)
+        }
       }, 2000)
       throw new this.hapErr(-70402)
     }
@@ -612,6 +676,20 @@ export default class {
           this.accessory.log(platformLang.alDisabled)
         }
       }
+    }
+
+    // Update any independently-controllable light zones (e.g. main/background)
+    if (params.toggles) {
+      Object.entries(this.zoneServices).forEach(([instance, service]) => {
+        if (hasProperty(params.toggles, instance)) {
+          const newValue = params.toggles[instance] ? 1 : 0
+          if (this.zoneCache[instance] !== newValue) {
+            this.zoneCache[instance] = newValue
+            service.updateCharacteristic(this.hapChar.On, newValue === 1)
+            this.accessory.log(`[${service.displayName}] ${platformLang.curState} [${newValue === 1 ? 'on' : 'off'}]`)
+          }
+        }
+      })
     }
   }
 }

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -128,6 +128,7 @@ export default {
 
   models: {
     rgb: [
+      'H1270', // Ceiling Light Ultra
       'H1401',
       'H1630',
       'H16B0', // https://github.com/homebridge-plugins/homebridge-govee/issues/1278


### PR DESCRIPTION
## Summary

- Adds H1270 (Ceiling Light Ultra) to `platformConsts.models.rgb` so the device is dispatched to the `deviceLight` handler instead of being logged as unsupported.
- Exposes the two independently controllable light zones (main/bottom panel and background/top edge light) as separate HomeKit Switch services on any device that reports `mainLightToggle` and/or `backgroundLightToggle` OpenAPI capabilities. Zone switches are only added when OpenAPI control is available and the capability is present; they are removed automatically if the capability disappears.
- External state updates (`externalUpdate`) sync zone switch state back to HomeKit when the Govee cloud reports a toggle change.

## Device tested

| Model | Name | Capabilities |
|-------|------|--------------|
| H1270 | Ceiling Light Ultra | `turn`, `bright`, `colour`, `colorTem`, `mainLightToggle`, `backgroundLightToggle` |

Confirmed working on a live H1270 via the OpenAPI transport (Govee API key configured). Both zones appear in Home.app as separate switches alongside the main Lightbulb tile.

## Test plan

- [ ] H1270 registers as a Lightbulb (not "unsupported") in Homebridge log
- [ ] Two additional Switch tiles appear in Home.app ("Main Light", "Background Light")
- [ ] Toggling each switch via HomeKit sends the correct `mainLightToggle`/`backgroundLightToggle` OpenAPI command
- [ ] Devices **without** these toggle capabilities are unaffected (no extra switches added)
- [ ] Devices without OpenAPI control configured are unaffected