### PR TITLE
Fix H7111 HomeKit RotationSpeed percentage mapping

### DIFF
--- a/lib/device/fan-H7111.js
+++ b/lib/device/fan-H7111.js
@@ -118,7 +118,7 @@ export default class {
     this.service
       .getCharacteristic(this.hapChar.RotationSpeed)
       .setProps({
-        maxValue: this.autoSpeed,
+        maxValue: 100,
         minStep: 1,
         minValue: 0,
         unit: 'unitless',
@@ -174,6 +174,13 @@ export default class {
       // Don't continue if the value is 0
       if (value === 0) {
         return
+      }
+
+      // HomeKit sends percentages
+      if (value >= 100) {
+         value = this.autoSpeed
+      } else if (value > 8) {
+         value = Math.max(1, Math.min(8, Math.round(value * 8 / 100)))
       }
 
       // Don't continue if the new value is the same as before
@@ -258,10 +265,14 @@ export default class {
       } else {
         newSpeed = params.workMode.modeValue
       }
-      if (Number.isFinite(newSpeed) && newSpeed >= 1 && newSpeed <= this.autoSpeed && this.cacheSpeed !== newSpeed) {
-        this.cacheSpeed = newSpeed
-        this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
-        this.accessory.log(`${platformLang.curSpeed} [${this.cacheSpeed}]`)
+      if (Number.isFinite(newSpeed) && newSpeed >= 1 && newSpeed <= this.autoSpeed) {
+        const hkSpeed = newSpeed === this.autoSpeed ? 100 : Math.round((newSpeed / 8) * 100)
+
+        if (this.cacheSpeed !== hkSpeed) {
+          this.cacheSpeed = hkSpeed
+          this.service.updateCharacteristic(this.hapChar.RotationSpeed, hkSpeed)
+          this.accessory.log(`${platformLang.curSpeed} [${newSpeed} -> ${hkSpeed}%]`)
+        }
       }
     }
 
@@ -276,7 +287,7 @@ export default class {
     }
 
     // Check for some other scene/mode change
-    (params.commands || []).forEach((command) => {
+    ;(params.commands || []).forEach((command) => {
       const hexString = base64ToHex(command)
       const hexParts = hexToTwoItems(hexString)
 
@@ -298,19 +309,21 @@ export default class {
         case '0501': {
           // Fan speed
           const newSpeed = Number.parseInt(getTwoItemPosition(hexParts, 4), 16)
-          if (newSpeed >= 1 && newSpeed <= 8 && this.cacheSpeed !== newSpeed) {
-            this.cacheSpeed = newSpeed
-            this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
-            this.accessory.log(`${platformLang.curSpeed} [${this.cacheSpeed}]`)
+          if (newSpeed >= 1 && newSpeed <= 8) {
+            const hkSpeed = Math.round((newSpeed / 8) * 100)
+
+            this.cacheSpeed = hkSpeed
+            this.service.updateCharacteristic(this.hapChar.RotationSpeed, hkSpeed)
+            this.accessory.log(`${platformLang.curSpeed} [${newSpeed} -> ${hkSpeed}%]`)
           }
           break
         }
         case '0500': {
           // Mode change (auto = 0x03)
           if (getTwoItemPosition(hexParts, 4) === '03' && this.cacheSpeed !== this.autoSpeed) {
-            this.cacheSpeed = this.autoSpeed
-            this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
-            this.accessory.log(`${platformLang.curSpeed} [auto]`)
+            this.cacheSpeed = 100
+            this.service.updateCharacteristic(this.hapChar.RotationSpeed, 100)
+            this.accessory.log(`${platformLang.curSpeed} [auto -> 100%]`)
           }
           break
         }

--- a/lib/device/fan-H7111.js
+++ b/lib/device/fan-H7111.js
@@ -178,9 +178,9 @@ export default class {
 
       // HomeKit sends percentages
       if (value >= 100) {
-         value = this.autoSpeed
+        value = this.autoSpeed
       } else if (value > 8) {
-         value = Math.max(1, Math.min(8, Math.round(value * 8 / 100)))
+        value = Math.max(1, Math.min(8, Math.round(value * 8 / 100)))
       }
 
       // Don't continue if the new value is the same as before


### PR DESCRIPTION
## Summary

Fixes incorrect HomeKit `RotationSpeed` handling for the H7111 Smart Air Circulator.

## Problem

The H7111 reports fan speeds as discrete values (1–8 plus Auto), while HomeKit exposes `RotationSpeed` as a percentage (0–100).

The existing implementation used the raw device values for the HomeKit characteristic, which caused:

- HomeKit speed changes to fail or behave unexpectedly.
- HomeKit to display speeds as 1–8 instead of percentages.
- Inconsistent synchronization between HomeKit and the Govee app.

## Solution

- Expose `RotationSpeed` as a 0–100 characteristic.
- Convert HomeKit percentages to Govee speed levels before sending commands.
- Convert Govee speed levels back to percentages when receiving updates from both OpenAPI and command events.
- Preserve existing behavior for on/off and oscillation.

## Testing

Tested with an H7111 Smart Air Circulator.

Verified:

- ✅ HomeKit → fan speed
- ✅ Govee app → HomeKit updates
- ✅ On/Off
- ✅ Oscillation
- ✅ AWS/OpenAPI updates