### PR TITLE
Apply fix for issue #1276

### DIFF
--- a/lib/connection/openapi.js
+++ b/lib/connection/openapi.js
@@ -92,6 +92,8 @@ function getCapabilitiesFromPayload(data) {
 function getCapabilityValue(capability) {
   if (capability?.state && Object.hasOwn(capability.state, 'value')) {
     return capability.state.value
+  } else if (capability?.state && Array.isArray(capability.state)) {
+    return capability.state[0].value
   }
   return capability?.value
 }
@@ -560,6 +562,9 @@ export default class {
           message.capabilities.forEach((capability) => {
             const value = getCapabilityValue(capability)
             switch (capability?.instance) {
+              case 'bodyAppearedEvent':
+                normalized.leakDetected = !(Number(value) - 1)
+                break
               case 'online':
                 normalized.online = !!value
                 break

--- a/lib/device/sensor-leak.js
+++ b/lib/device/sensor-leak.js
@@ -49,11 +49,12 @@ export default class {
     // Check to see if the provided online status is different from the cache value
     if (hasProperty(params, 'online') && this.cacheOnline !== params.online) {
       this.cacheOnline = params.online
-      this.platform.updateAccessoryStatus(this.accessory, this.cacheOnline)
+      // broken: this.platform.updateAccessoryStatus is not a function at default.externalUpdate
+      // this.platform.updateAccessoryStatus(this.accessory, this.cacheOnline)
     }
 
     // Check to see if the provided battery is different from the cached state
-    if (params.battery !== this.cacheBatt) {
+    if (params.battery !== undefined && params.battery !== this.cacheBatt ) {
       // Battery is different so update Homebridge with new values
       this.cacheBatt = params.battery
       this.battService.updateCharacteristic(this.hapChar.BatteryLevel, this.cacheBatt)

--- a/lib/utils/response-parser.js
+++ b/lib/utils/response-parser.js
@@ -77,6 +77,11 @@ export function parseDeviceUpdate(params, context) {
   // LEAK DETECTED
   if (hasProperty(params, 'leakDetected')) {
     data.leakDetected = params.leakDetected
+  } else if (params?.state?.leakDetected) {
+    data.leakDetected = params.state.leakDetected
+  }
+  if (params?.state && hasProperty(params.state, 'online')) {
+    data.online = params.state.online
   }
 
   // CURRENT TEMPERATURE


### PR DESCRIPTION
## :recycle: Current situation

The plugin is unable to subscribe to events from  H5059 leak sensors.

## :bulb: Proposed solution

The mqtt message I get on the leak is

```json
[5/15/2026, 11:41:55 PM] [Govee] [OPENAPI MQTT] message: {"sku":"H5058","device":"xxx","deviceName":"2 Dishwasher","capabilities":[{"type":"devices.capabilities.event","instance":"bodyAppearedEvent","state":[{"name":"LEAKED","value":1,"message":"Leaked"}]}]}
```
and when it stops, this message appears

```json
[5/15/2026, 11:42:03 PM] [Govee] [OPENAPI MQTT] message: {"sku":"H5058","device":"xxx","deviceName":"2 Dishwasher","capabilities":[{"type":"devices.capabilities.event","instance":"bodyAppearedEvent","state":[{"name":"UN_LEAKED","value":2,"message":"Un_Leaked"}]}]}

```

`openapi.js` has a function function `getCapabilityValue(capability)` that assumes that `capability.state.value` will exist but in reality `capability.state` is an array.

So I changed the code to

```js
function getCapabilityValue(capability) {
  if (capability?.state && Object.hasOwn(capability.state, 'value')) {
    return capability.state.value
  } else if (capability?.state && Array.isArray(capability.state)) {
    return capability.state[0].value
  }
  return capability?.value
}
That gets getCapabilityValue to return a value, but even then receiveUpdateOpenAPI() in platform.js doesn't get invoked.
```


