### PR TITLE
fix(ice-makers): stop the Home app showing "0" for ice size

### DIFF
--- a/lib/device/fan-H1310.js
+++ b/lib/device/fan-H1310.js
@@ -1,7 +1,9 @@
 import {
   base64ToHex,
+  fanSpeedToHkPercent,
   getTwoItemPosition,
   hexToTwoItems,
+  hkPercentToFanSpeed,
   parseError,
 } from '../utils/functions.js'
 import platformLang from '../utils/lang-en.js'
@@ -30,6 +32,8 @@ export default class {
       9: 'MwUAAwAAAAAAAAAAAAAAAAAAADU=', // auto mode
     }
     this.autoSpeed = 9
+    // Real speed steps, excluding auto - HomeKit percentages map onto these
+    this.speedSteps = 8
 
     // Remove any old original Fan services
     if (this.accessory.getService(this.hapServ.Fan)) {
@@ -57,7 +61,7 @@ export default class {
     this.service
       .getCharacteristic(this.hapChar.RotationSpeed)
       .setProps({
-        maxValue: this.autoSpeed,
+        maxValue: 100,
         minStep: 1,
         minValue: 0,
         unit: 'unitless',
@@ -115,6 +119,9 @@ export default class {
         return
       }
 
+      // HomeKit sends a percentage - map it onto this model's real speed steps
+      value = hkPercentToFanSpeed(value, this.speedSteps)
+
       // Don't continue if the new value is the same as before
       if (this.cacheSpeed === value) {
         return
@@ -142,7 +149,7 @@ export default class {
 
       // Throw a 'no response' error and set a timeout to revert this after 2 seconds
       setTimeout(() => {
-        this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
+        this.service.updateCharacteristic(this.hapChar.RotationSpeed, fanSpeedToHkPercent(this.cacheSpeed, this.speedSteps, this.autoSpeed))
       }, 2000)
       throw new this.hapErr(-70402)
     }
@@ -199,8 +206,9 @@ export default class {
       }
       if (Number.isFinite(newSpeed) && newSpeed >= 1 && newSpeed <= this.autoSpeed && this.cacheSpeed !== newSpeed) {
         this.cacheSpeed = newSpeed
-        this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
-        this.accessory.log(`${platformLang.curSpeed} [${this.cacheSpeed}]`)
+        const hkSpeed = fanSpeedToHkPercent(newSpeed, this.speedSteps, this.autoSpeed)
+        this.service.updateCharacteristic(this.hapChar.RotationSpeed, hkSpeed)
+        this.accessory.log(`${platformLang.curSpeed} [${newSpeed} -> ${hkSpeed}%]`)
       }
     }
 
@@ -237,10 +245,11 @@ export default class {
         case '0501': {
           // Fan speed
           const newSpeed = Number.parseInt(getTwoItemPosition(hexParts, 4), 16)
-          if (newSpeed >= 1 && newSpeed <= 8 && this.cacheSpeed !== newSpeed) {
+          if (newSpeed >= 1 && newSpeed <= this.speedSteps && this.cacheSpeed !== newSpeed) {
             this.cacheSpeed = newSpeed
-            this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
-            this.accessory.log(`${platformLang.curSpeed} [${this.cacheSpeed}]`)
+            const hkSpeed = fanSpeedToHkPercent(newSpeed, this.speedSteps, this.autoSpeed)
+            this.service.updateCharacteristic(this.hapChar.RotationSpeed, hkSpeed)
+            this.accessory.log(`${platformLang.curSpeed} [${newSpeed} -> ${hkSpeed}%]`)
           }
           break
         }
@@ -248,7 +257,8 @@ export default class {
           // Mode change (auto = 0x03)
           if (getTwoItemPosition(hexParts, 4) === '03' && this.cacheSpeed !== this.autoSpeed) {
             this.cacheSpeed = this.autoSpeed
-            this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
+            // Cache auto so we can tell it apart from "user asked for max speed"
+            this.service.updateCharacteristic(this.hapChar.RotationSpeed, 100)
             this.accessory.log(`${platformLang.curSpeed} [auto]`)
           }
           break

--- a/lib/device/fan-H1370.js
+++ b/lib/device/fan-H1370.js
@@ -1,9 +1,11 @@
 import {
   base64ToHex,
+  fanSpeedToHkPercent,
   generateCodeFromHexValues,
   generateRandomString,
   getTwoItemPosition,
   hexToTwoItems,
+  hkPercentToFanSpeed,
   parseError,
   sleep,
 } from '../utils/functions.js'
@@ -41,11 +43,14 @@ export default class {
       .onSet(async value => this.internalStateUpdate(value))
     this.cacheState = this.service.getCharacteristic(this.hapChar.Active).value ? 'on' : 'off'
 
+    // Real speed steps - HomeKit percentages map onto these
+    this.speedSteps = 12
+
     // Add the set handler to the fan rotation speed characteristic
     this.service
       .getCharacteristic(this.hapChar.RotationSpeed)
       .setProps({
-        maxValue: 12,
+        maxValue: 100,
         minStep: 1,
         minValue: 0,
         unit: 'unitless',
@@ -140,6 +145,9 @@ export default class {
         return
       }
 
+      // HomeKit sends a percentage - map it onto this model's real speed steps
+      value = hkPercentToFanSpeed(value, this.speedSteps)
+
       // Don't continue if the new value is the same as before
       if (this.cacheSpeed === value) {
         return
@@ -162,7 +170,7 @@ export default class {
 
       // Throw a 'no response' error and set a timeout to revert this after 2 seconds
       setTimeout(() => {
-        this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
+        this.service.updateCharacteristic(this.hapChar.RotationSpeed, fanSpeedToHkPercent(this.cacheSpeed, this.speedSteps))
       }, 2000)
       throw new this.hapErr(-70402)
     }
@@ -320,10 +328,11 @@ export default class {
         case '3101': {
           // Fan speed
           const newSpeed = Number.parseInt(getTwoItemPosition(hexParts, 4), 16)
-          if (newSpeed >= 1 && newSpeed <= 12 && this.cacheSpeed !== newSpeed) {
+          if (newSpeed >= 1 && newSpeed <= this.speedSteps && this.cacheSpeed !== newSpeed) {
             this.cacheSpeed = newSpeed
-            this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
-            this.accessory.log(`${platformLang.curSpeed} [${this.cacheSpeed}]`)
+            const hkSpeed = fanSpeedToHkPercent(newSpeed, this.speedSteps)
+            this.service.updateCharacteristic(this.hapChar.RotationSpeed, hkSpeed)
+            this.accessory.log(`${platformLang.curSpeed} [${newSpeed} -> ${hkSpeed}%]`)
           }
           break
         }

--- a/lib/device/fan-H7100.js
+++ b/lib/device/fan-H7100.js
@@ -1,7 +1,9 @@
 import {
   base64ToHex,
+  fanSpeedToHkPercent,
   getTwoItemPosition,
   hexToTwoItems,
+  hkPercentToFanSpeed,
   parseError,
 } from '../utils/functions.js'
 import platformLang from '../utils/lang-en.js'
@@ -30,6 +32,8 @@ export default class {
       9: 'MwUAAwAAAAAAAAAAAAAAAAAAADU=', // auto mode
     }
     this.autoSpeed = 9
+    // Real speed steps, excluding auto - HomeKit percentages map onto these
+    this.speedSteps = 8
 
     // Remove any old original Fan services
     if (this.accessory.getService(this.hapServ.Fan)) {
@@ -57,7 +61,7 @@ export default class {
     this.service
       .getCharacteristic(this.hapChar.RotationSpeed)
       .setProps({
-        maxValue: this.autoSpeed,
+        maxValue: 100,
         minStep: 1,
         minValue: 0,
         unit: 'unitless',
@@ -115,6 +119,9 @@ export default class {
         return
       }
 
+      // HomeKit sends a percentage - map it onto this model's real speed steps
+      value = hkPercentToFanSpeed(value, this.speedSteps)
+
       // Don't continue if the new value is the same as before
       if (this.cacheSpeed === value) {
         return
@@ -142,7 +149,7 @@ export default class {
 
       // Throw a 'no response' error and set a timeout to revert this after 2 seconds
       setTimeout(() => {
-        this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
+        this.service.updateCharacteristic(this.hapChar.RotationSpeed, fanSpeedToHkPercent(this.cacheSpeed, this.speedSteps, this.autoSpeed))
       }, 2000)
       throw new this.hapErr(-70402)
     }
@@ -199,8 +206,9 @@ export default class {
       }
       if (Number.isFinite(newSpeed) && newSpeed >= 1 && newSpeed <= this.autoSpeed && this.cacheSpeed !== newSpeed) {
         this.cacheSpeed = newSpeed
-        this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
-        this.accessory.log(`${platformLang.curSpeed} [${this.cacheSpeed}]`)
+        const hkSpeed = fanSpeedToHkPercent(newSpeed, this.speedSteps, this.autoSpeed)
+        this.service.updateCharacteristic(this.hapChar.RotationSpeed, hkSpeed)
+        this.accessory.log(`${platformLang.curSpeed} [${newSpeed} -> ${hkSpeed}%]`)
       }
     }
 
@@ -237,10 +245,11 @@ export default class {
         case '0501': {
           // Fan speed
           const newSpeed = Number.parseInt(getTwoItemPosition(hexParts, 4), 16)
-          if (newSpeed >= 1 && newSpeed <= 8 && this.cacheSpeed !== newSpeed) {
+          if (newSpeed >= 1 && newSpeed <= this.speedSteps && this.cacheSpeed !== newSpeed) {
             this.cacheSpeed = newSpeed
-            this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
-            this.accessory.log(`${platformLang.curSpeed} [${this.cacheSpeed}]`)
+            const hkSpeed = fanSpeedToHkPercent(newSpeed, this.speedSteps, this.autoSpeed)
+            this.service.updateCharacteristic(this.hapChar.RotationSpeed, hkSpeed)
+            this.accessory.log(`${platformLang.curSpeed} [${newSpeed} -> ${hkSpeed}%]`)
           }
           break
         }
@@ -248,7 +257,8 @@ export default class {
           // Mode change (auto = 0x03)
           if (getTwoItemPosition(hexParts, 4) === '03' && this.cacheSpeed !== this.autoSpeed) {
             this.cacheSpeed = this.autoSpeed
-            this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
+            // Cache auto so we can tell it apart from "user asked for max speed"
+            this.service.updateCharacteristic(this.hapChar.RotationSpeed, 100)
             this.accessory.log(`${platformLang.curSpeed} [auto]`)
           }
           break

--- a/lib/device/fan-H7101.js
+++ b/lib/device/fan-H7101.js
@@ -1,7 +1,9 @@
 import {
   base64ToHex,
+  fanSpeedToHkPercent,
   getTwoItemPosition,
   hexToTwoItems,
+  hkPercentToFanSpeed,
   parseError,
 } from '../utils/functions.js'
 import platformLang from '../utils/lang-en.js'
@@ -86,6 +88,8 @@ export default class {
       9: 'MwUAAwAAAAAAAAAAAAAAAAAAADU=', // auto mode
     }
     this.autoSpeed = 9
+    // Real speed steps, excluding auto - HomeKit percentages map onto these
+    this.speedSteps = 8
 
     // Remove any old original Fan services
     if (this.accessory.getService(this.hapServ.Fan)) {
@@ -113,7 +117,7 @@ export default class {
     this.service
       .getCharacteristic(this.hapChar.RotationSpeed)
       .setProps({
-        maxValue: this.autoSpeed,
+        maxValue: 100,
         minStep: 1,
         minValue: 0,
         unit: 'unitless',
@@ -171,6 +175,9 @@ export default class {
         return
       }
 
+      // HomeKit sends a percentage - map it onto this model's real speed steps
+      value = hkPercentToFanSpeed(value, this.speedSteps)
+
       // Don't continue if the new value is the same as before
       if (this.cacheSpeed === value) {
         return
@@ -198,7 +205,7 @@ export default class {
 
       // Throw a 'no response' error and set a timeout to revert this after 2 seconds
       setTimeout(() => {
-        this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
+        this.service.updateCharacteristic(this.hapChar.RotationSpeed, fanSpeedToHkPercent(this.cacheSpeed, this.speedSteps, this.autoSpeed))
       }, 2000)
       throw new this.hapErr(-70402)
     }
@@ -255,8 +262,9 @@ export default class {
       }
       if (Number.isFinite(newSpeed) && newSpeed >= 1 && newSpeed <= this.autoSpeed && this.cacheSpeed !== newSpeed) {
         this.cacheSpeed = newSpeed
-        this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
-        this.accessory.log(`${platformLang.curSpeed} [${this.cacheSpeed}]`)
+        const hkSpeed = fanSpeedToHkPercent(newSpeed, this.speedSteps, this.autoSpeed)
+        this.service.updateCharacteristic(this.hapChar.RotationSpeed, hkSpeed)
+        this.accessory.log(`${platformLang.curSpeed} [${newSpeed} -> ${hkSpeed}%]`)
       }
     }
 
@@ -293,10 +301,11 @@ export default class {
         case '0501': {
           // Fan speed
           const newSpeed = Number.parseInt(getTwoItemPosition(hexParts, 4), 16)
-          if (newSpeed >= 1 && newSpeed <= 8 && this.cacheSpeed !== newSpeed) {
+          if (newSpeed >= 1 && newSpeed <= this.speedSteps && this.cacheSpeed !== newSpeed) {
             this.cacheSpeed = newSpeed
-            this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
-            this.accessory.log(`${platformLang.curSpeed} [${this.cacheSpeed}]`)
+            const hkSpeed = fanSpeedToHkPercent(newSpeed, this.speedSteps, this.autoSpeed)
+            this.service.updateCharacteristic(this.hapChar.RotationSpeed, hkSpeed)
+            this.accessory.log(`${platformLang.curSpeed} [${newSpeed} -> ${hkSpeed}%]`)
           }
           break
         }
@@ -304,7 +313,8 @@ export default class {
           // Mode change (auto = 0x03)
           if (getTwoItemPosition(hexParts, 4) === '03' && this.cacheSpeed !== this.autoSpeed) {
             this.cacheSpeed = this.autoSpeed
-            this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
+            // Cache auto so we can tell it apart from "user asked for max speed"
+            this.service.updateCharacteristic(this.hapChar.RotationSpeed, 100)
             this.accessory.log(`${platformLang.curSpeed} [auto]`)
           }
           break

--- a/lib/device/fan-H7102.js
+++ b/lib/device/fan-H7102.js
@@ -1,7 +1,9 @@
 import {
   base64ToHex,
+  fanSpeedToHkPercent,
   getTwoItemPosition,
   hexToTwoItems,
+  hkPercentToFanSpeed,
   parseError,
 } from '../utils/functions.js'
 import platformLang from '../utils/lang-en.js'
@@ -30,6 +32,8 @@ export default class {
       9: 'MwUAAwAAAAAAAAAAAAAAAAAAADU=', // auto mode
     }
     this.autoSpeed = 9
+    // Real speed steps, excluding auto - HomeKit percentages map onto these
+    this.speedSteps = 8
 
     // Remove any old original Fan services
     if (this.accessory.getService(this.hapServ.Fan)) {
@@ -57,7 +61,7 @@ export default class {
     this.service
       .getCharacteristic(this.hapChar.RotationSpeed)
       .setProps({
-        maxValue: this.autoSpeed,
+        maxValue: 100,
         minStep: 1,
         minValue: 0,
         unit: 'unitless',
@@ -115,6 +119,9 @@ export default class {
         return
       }
 
+      // HomeKit sends a percentage - map it onto this model's real speed steps
+      value = hkPercentToFanSpeed(value, this.speedSteps)
+
       // Don't continue if the new value is the same as before
       if (this.cacheSpeed === value) {
         return
@@ -142,7 +149,7 @@ export default class {
 
       // Throw a 'no response' error and set a timeout to revert this after 2 seconds
       setTimeout(() => {
-        this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
+        this.service.updateCharacteristic(this.hapChar.RotationSpeed, fanSpeedToHkPercent(this.cacheSpeed, this.speedSteps, this.autoSpeed))
       }, 2000)
       throw new this.hapErr(-70402)
     }
@@ -199,8 +206,9 @@ export default class {
       }
       if (Number.isFinite(newSpeed) && newSpeed >= 1 && newSpeed <= this.autoSpeed && this.cacheSpeed !== newSpeed) {
         this.cacheSpeed = newSpeed
-        this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
-        this.accessory.log(`${platformLang.curSpeed} [${this.cacheSpeed}]`)
+        const hkSpeed = fanSpeedToHkPercent(newSpeed, this.speedSteps, this.autoSpeed)
+        this.service.updateCharacteristic(this.hapChar.RotationSpeed, hkSpeed)
+        this.accessory.log(`${platformLang.curSpeed} [${newSpeed} -> ${hkSpeed}%]`)
       }
     }
 
@@ -237,10 +245,11 @@ export default class {
         case '0501': {
           // Fan speed
           const newSpeed = Number.parseInt(getTwoItemPosition(hexParts, 4), 16)
-          if (newSpeed >= 1 && newSpeed <= 8 && this.cacheSpeed !== newSpeed) {
+          if (newSpeed >= 1 && newSpeed <= this.speedSteps && this.cacheSpeed !== newSpeed) {
             this.cacheSpeed = newSpeed
-            this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
-            this.accessory.log(`${platformLang.curSpeed} [${this.cacheSpeed}]`)
+            const hkSpeed = fanSpeedToHkPercent(newSpeed, this.speedSteps, this.autoSpeed)
+            this.service.updateCharacteristic(this.hapChar.RotationSpeed, hkSpeed)
+            this.accessory.log(`${platformLang.curSpeed} [${newSpeed} -> ${hkSpeed}%]`)
           }
           break
         }
@@ -248,7 +257,8 @@ export default class {
           // Mode change (auto = 0x03)
           if (getTwoItemPosition(hexParts, 4) === '03' && this.cacheSpeed !== this.autoSpeed) {
             this.cacheSpeed = this.autoSpeed
-            this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
+            // Cache auto so we can tell it apart from "user asked for max speed"
+            this.service.updateCharacteristic(this.hapChar.RotationSpeed, 100)
             this.accessory.log(`${platformLang.curSpeed} [auto]`)
           }
           break

--- a/lib/device/fan-H7105.js
+++ b/lib/device/fan-H7105.js
@@ -1,11 +1,13 @@
 import { hs2rgb, rgb2hs } from '../utils/colour.js'
 import {
   base64ToHex,
+  fanSpeedToHkPercent,
   generateCodeFromHexValues,
   generateRandomString,
   getTwoItemPosition,
   hexToDecimal,
   hexToTwoItems,
+  hkPercentToFanSpeed,
   parseError,
   sleep,
 } from '../utils/functions.js'
@@ -43,6 +45,8 @@ export default class {
       13: 'MwUAAgAAAAAAAAAAAAAAAAAAADQ=', // auto mode
     }
     this.autoSpeed = 13
+    // Real speed steps, excluding auto - HomeKit percentages map onto these
+    this.speedSteps = 12
 
     // Remove any old original Fan services
     if (this.accessory.getService(this.hapServ.Fan)) {
@@ -70,7 +74,7 @@ export default class {
     this.service
       .getCharacteristic(this.hapChar.RotationSpeed)
       .setProps({
-        maxValue: this.autoSpeed,
+        maxValue: 100,
         minStep: 1,
         minValue: 0,
         unit: 'unitless', // This is actually from HAP for Bluetooth LE Specification, but fits
@@ -157,8 +161,16 @@ export default class {
 
   async internalSpeedUpdate(value) {
     try {
+      // Don't continue if the fan is being turned off
+      if (value === 0) {
+        return
+      }
+
+      // HomeKit sends a percentage - map it onto this model's real speed steps
+      value = hkPercentToFanSpeed(value, this.speedSteps)
+
       // Don't continue if the new value is the same as before
-      if (this.cacheSpeed === value || value === 0) {
+      if (this.cacheSpeed === value) {
         return
       }
 
@@ -182,7 +194,7 @@ export default class {
 
       // Throw a 'no response' error and set a timeout to revert this after 2 seconds
       setTimeout(() => {
-        this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
+        this.service.updateCharacteristic(this.hapChar.RotationSpeed, fanSpeedToHkPercent(this.cacheSpeed, this.speedSteps, this.autoSpeed))
       }, 2000)
       throw new this.hapErr(-70402)
     }
@@ -380,8 +392,9 @@ export default class {
       }
       if (Number.isFinite(newSpeed) && newSpeed >= 1 && newSpeed <= this.autoSpeed && this.cacheSpeed !== newSpeed) {
         this.cacheSpeed = newSpeed
-        this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
-        this.accessory.log(`${platformLang.curSpeed} [${this.cacheSpeed}]`)
+        const hkSpeed = fanSpeedToHkPercent(newSpeed, this.speedSteps, this.autoSpeed)
+        this.service.updateCharacteristic(this.hapChar.RotationSpeed, hkSpeed)
+        this.accessory.log(`${platformLang.curSpeed} [${newSpeed} -> ${hkSpeed}%]`)
       }
     }
 
@@ -430,7 +443,8 @@ export default class {
           // Mode change (auto = 0x02)
           if (getTwoItemPosition(hexParts, 4) === '02' && this.cacheSpeed !== this.autoSpeed) {
             this.cacheSpeed = this.autoSpeed
-            this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
+            // Cache auto so we can tell it apart from "user asked for max speed"
+            this.service.updateCharacteristic(this.hapChar.RotationSpeed, 100)
             this.accessory.log(`${platformLang.curSpeed} [auto]`)
           }
           break

--- a/lib/device/fan-H7106.js
+++ b/lib/device/fan-H7106.js
@@ -1,7 +1,9 @@
 import {
   base64ToHex,
+  fanSpeedToHkPercent,
   getTwoItemPosition,
   hexToTwoItems,
+  hkPercentToFanSpeed,
   parseError,
 } from '../utils/functions.js'
 import platformLang from '../utils/lang-en.js'
@@ -30,6 +32,8 @@ export default class {
       9: 'MwUAAwAAAAAAAAAAAAAAAAAAADU=', // auto mode
     }
     this.autoSpeed = 9
+    // Real speed steps, excluding auto - HomeKit percentages map onto these
+    this.speedSteps = 8
 
     // Remove any old original Fan services
     if (this.accessory.getService(this.hapServ.Fan)) {
@@ -57,7 +61,7 @@ export default class {
     this.service
       .getCharacteristic(this.hapChar.RotationSpeed)
       .setProps({
-        maxValue: this.autoSpeed,
+        maxValue: 100,
         minStep: 1,
         minValue: 0,
         unit: 'unitless',
@@ -115,6 +119,9 @@ export default class {
         return
       }
 
+      // HomeKit sends a percentage - map it onto this model's real speed steps
+      value = hkPercentToFanSpeed(value, this.speedSteps)
+
       // Don't continue if the new value is the same as before
       if (this.cacheSpeed === value) {
         return
@@ -142,7 +149,7 @@ export default class {
 
       // Throw a 'no response' error and set a timeout to revert this after 2 seconds
       setTimeout(() => {
-        this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
+        this.service.updateCharacteristic(this.hapChar.RotationSpeed, fanSpeedToHkPercent(this.cacheSpeed, this.speedSteps, this.autoSpeed))
       }, 2000)
       throw new this.hapErr(-70402)
     }
@@ -199,8 +206,9 @@ export default class {
       }
       if (Number.isFinite(newSpeed) && newSpeed >= 1 && newSpeed <= this.autoSpeed && this.cacheSpeed !== newSpeed) {
         this.cacheSpeed = newSpeed
-        this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
-        this.accessory.log(`${platformLang.curSpeed} [${this.cacheSpeed}]`)
+        const hkSpeed = fanSpeedToHkPercent(newSpeed, this.speedSteps, this.autoSpeed)
+        this.service.updateCharacteristic(this.hapChar.RotationSpeed, hkSpeed)
+        this.accessory.log(`${platformLang.curSpeed} [${newSpeed} -> ${hkSpeed}%]`)
       }
     }
 
@@ -237,10 +245,11 @@ export default class {
         case '0501': {
           // Fan speed
           const newSpeed = Number.parseInt(getTwoItemPosition(hexParts, 4), 16)
-          if (newSpeed >= 1 && newSpeed <= 8 && this.cacheSpeed !== newSpeed) {
+          if (newSpeed >= 1 && newSpeed <= this.speedSteps && this.cacheSpeed !== newSpeed) {
             this.cacheSpeed = newSpeed
-            this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
-            this.accessory.log(`${platformLang.curSpeed} [${this.cacheSpeed}]`)
+            const hkSpeed = fanSpeedToHkPercent(newSpeed, this.speedSteps, this.autoSpeed)
+            this.service.updateCharacteristic(this.hapChar.RotationSpeed, hkSpeed)
+            this.accessory.log(`${platformLang.curSpeed} [${newSpeed} -> ${hkSpeed}%]`)
           }
           break
         }
@@ -248,7 +257,8 @@ export default class {
           // Mode change (auto = 0x03)
           if (getTwoItemPosition(hexParts, 4) === '03' && this.cacheSpeed !== this.autoSpeed) {
             this.cacheSpeed = this.autoSpeed
-            this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
+            // Cache auto so we can tell it apart from "user asked for max speed"
+            this.service.updateCharacteristic(this.hapChar.RotationSpeed, 100)
             this.accessory.log(`${platformLang.curSpeed} [auto]`)
           }
           break

--- a/lib/device/fan-H7107.js
+++ b/lib/device/fan-H7107.js
@@ -1,11 +1,13 @@
 import { hs2rgb, rgb2hs } from '../utils/colour.js'
 import {
   base64ToHex,
+  fanSpeedToHkPercent,
   generateCodeFromHexValues,
   generateRandomString,
   getTwoItemPosition,
   hexToDecimal,
   hexToTwoItems,
+  hkPercentToFanSpeed,
   parseError,
   sleep,
 } from '../utils/functions.js'
@@ -43,6 +45,8 @@ export default class {
       13: 'MwUAAgAAAAAAAAAAAAAAAAAAADQ=', // auto mode
     }
     this.autoSpeed = 13
+    // Real speed steps, excluding auto - HomeKit percentages map onto these
+    this.speedSteps = 12
 
     // Remove any old original Fan services
     if (this.accessory.getService(this.hapServ.Fan)) {
@@ -70,7 +74,7 @@ export default class {
     this.service
       .getCharacteristic(this.hapChar.RotationSpeed)
       .setProps({
-        maxValue: this.autoSpeed,
+        maxValue: 100,
         minStep: 1,
         minValue: 0,
         unit: 'unitless', // This is actually from HAP for Bluetooth LE Specification, but fits
@@ -157,8 +161,16 @@ export default class {
 
   async internalSpeedUpdate(value) {
     try {
+      // Don't continue if the fan is being turned off
+      if (value === 0) {
+        return
+      }
+
+      // HomeKit sends a percentage - map it onto this model's real speed steps
+      value = hkPercentToFanSpeed(value, this.speedSteps)
+
       // Don't continue if the new value is the same as before
-      if (this.cacheSpeed === value || value === 0) {
+      if (this.cacheSpeed === value) {
         return
       }
 
@@ -182,7 +194,7 @@ export default class {
 
       // Throw a 'no response' error and set a timeout to revert this after 2 seconds
       setTimeout(() => {
-        this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
+        this.service.updateCharacteristic(this.hapChar.RotationSpeed, fanSpeedToHkPercent(this.cacheSpeed, this.speedSteps, this.autoSpeed))
       }, 2000)
       throw new this.hapErr(-70402)
     }
@@ -380,8 +392,9 @@ export default class {
       }
       if (Number.isFinite(newSpeed) && newSpeed >= 1 && newSpeed <= this.autoSpeed && this.cacheSpeed !== newSpeed) {
         this.cacheSpeed = newSpeed
-        this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
-        this.accessory.log(`${platformLang.curSpeed} [${this.cacheSpeed}]`)
+        const hkSpeed = fanSpeedToHkPercent(newSpeed, this.speedSteps, this.autoSpeed)
+        this.service.updateCharacteristic(this.hapChar.RotationSpeed, hkSpeed)
+        this.accessory.log(`${platformLang.curSpeed} [${newSpeed} -> ${hkSpeed}%]`)
       }
     }
 
@@ -430,7 +443,8 @@ export default class {
           // Mode change (auto = 0x02)
           if (getTwoItemPosition(hexParts, 4) === '02' && this.cacheSpeed !== this.autoSpeed) {
             this.cacheSpeed = this.autoSpeed
-            this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
+            // Cache auto so we can tell it apart from "user asked for max speed"
+            this.service.updateCharacteristic(this.hapChar.RotationSpeed, 100)
             this.accessory.log(`${platformLang.curSpeed} [auto]`)
           }
           break

--- a/lib/device/fan-H7111.js
+++ b/lib/device/fan-H7111.js
@@ -1,7 +1,9 @@
 import {
   base64ToHex,
+  fanSpeedToHkPercent,
   getTwoItemPosition,
   hexToTwoItems,
+  hkPercentToFanSpeed,
   parseError,
 } from '../utils/functions.js'
 import platformLang from '../utils/lang-en.js'
@@ -91,6 +93,8 @@ export default class {
       9: 'MwUAAwAAAAAAAAAAAAAAAAAAADU=', // auto mode
     }
     this.autoSpeed = 9
+    // Real speed steps, excluding auto - HomeKit percentages map onto these
+    this.speedSteps = 8
 
     // Remove any old original Fan services
     if (this.accessory.getService(this.hapServ.Fan)) {
@@ -176,12 +180,8 @@ export default class {
         return
       }
 
-      // HomeKit sends percentages
-      if (value >= 100) {
-        value = this.autoSpeed
-      } else if (value > 8) {
-        value = Math.max(1, Math.min(8, Math.round(value * 8 / 100)))
-      }
+      // HomeKit sends a percentage - map it onto this model's real speed steps
+      value = hkPercentToFanSpeed(value, this.speedSteps)
 
       // Don't continue if the new value is the same as before
       if (this.cacheSpeed === value) {
@@ -210,7 +210,7 @@ export default class {
 
       // Throw a 'no response' error and set a timeout to revert this after 2 seconds
       setTimeout(() => {
-        this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSpeed)
+        this.service.updateCharacteristic(this.hapChar.RotationSpeed, fanSpeedToHkPercent(this.cacheSpeed, this.speedSteps, this.autoSpeed))
       }, 2000)
       throw new this.hapErr(-70402)
     }
@@ -265,14 +265,11 @@ export default class {
       } else {
         newSpeed = params.workMode.modeValue
       }
-      if (Number.isFinite(newSpeed) && newSpeed >= 1 && newSpeed <= this.autoSpeed) {
-        const hkSpeed = newSpeed === this.autoSpeed ? 100 : Math.round((newSpeed / 8) * 100)
-
-        if (this.cacheSpeed !== hkSpeed) {
-          this.cacheSpeed = hkSpeed
-          this.service.updateCharacteristic(this.hapChar.RotationSpeed, hkSpeed)
-          this.accessory.log(`${platformLang.curSpeed} [${newSpeed} -> ${hkSpeed}%]`)
-        }
+      if (Number.isFinite(newSpeed) && newSpeed >= 1 && newSpeed <= this.autoSpeed && this.cacheSpeed !== newSpeed) {
+        this.cacheSpeed = newSpeed
+        const hkSpeed = fanSpeedToHkPercent(newSpeed, this.speedSteps, this.autoSpeed)
+        this.service.updateCharacteristic(this.hapChar.RotationSpeed, hkSpeed)
+        this.accessory.log(`${platformLang.curSpeed} [${newSpeed} -> ${hkSpeed}%]`)
       }
     }
 
@@ -309,10 +306,9 @@ export default class {
         case '0501': {
           // Fan speed
           const newSpeed = Number.parseInt(getTwoItemPosition(hexParts, 4), 16)
-          if (newSpeed >= 1 && newSpeed <= 8) {
-            const hkSpeed = Math.round((newSpeed / 8) * 100)
-
-            this.cacheSpeed = hkSpeed
+          if (newSpeed >= 1 && newSpeed <= this.speedSteps && this.cacheSpeed !== newSpeed) {
+            this.cacheSpeed = newSpeed
+            const hkSpeed = fanSpeedToHkPercent(newSpeed, this.speedSteps, this.autoSpeed)
             this.service.updateCharacteristic(this.hapChar.RotationSpeed, hkSpeed)
             this.accessory.log(`${platformLang.curSpeed} [${newSpeed} -> ${hkSpeed}%]`)
           }
@@ -321,7 +317,8 @@ export default class {
         case '0500': {
           // Mode change (auto = 0x03)
           if (getTwoItemPosition(hexParts, 4) === '03' && this.cacheSpeed !== this.autoSpeed) {
-            this.cacheSpeed = 100
+            // Cache auto so we can tell it apart from "user asked for max speed"
+            this.cacheSpeed = this.autoSpeed
             this.service.updateCharacteristic(this.hapChar.RotationSpeed, 100)
             this.accessory.log(`${platformLang.curSpeed} [auto -> 100%]`)
           }

--- a/lib/device/ice-maker-H7172.js
+++ b/lib/device/ice-maker-H7172.js
@@ -52,6 +52,13 @@ export default class {
       .onSet(async value => this.internalSizeUpdate(value))
     this.cacheSize = this.service.getCharacteristic(this.hapChar.RotationSpeed).value || 2
 
+    // Keep the characteristic in step with the cache. Without this an accessory
+    // that has never had a size set reports Active=1 with RotationSpeed=0, which
+    // is contradictory and which the Home app renders as "0".
+    if (this.service.getCharacteristic(this.hapChar.RotationSpeed).value !== this.cacheSize) {
+      this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSize)
+    }
+
     // Output the customised options to the log
     const opts = JSON.stringify({})
     platform.log('[%s] %s %s.', accessory.displayName, platformLang.devInitOpts, opts)
@@ -105,8 +112,15 @@ export default class {
 
   async internalSizeUpdate(value) {
     try {
-      // Don't continue if 0
+      // 0 is not a valid ice size. Put the slider back, otherwise HomeKit keeps 0
+      // while the device carries on at cacheSize - and that 0 is what gets written
+      // to the accessory cache, so it returns on the next restart. Deferred for the
+      // same reason as the error reverts below: an immediate update would be
+      // overwritten by the value HomeKit is currently writing.
       if (value === 0) {
+        setTimeout(() => {
+          this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSize)
+        }, 1000)
         return
       }
 
@@ -145,8 +159,11 @@ export default class {
     if (params.workMode) {
       const mode = params.workMode.workMode
       if (mode > 0 && mode <= 3) {
-        this.cacheState = 'on'
-        this.service.updateCharacteristic(this.hapChar.Active, 1)
+        if (this.cacheState !== 'on') {
+          this.cacheState = 'on'
+          this.service.updateCharacteristic(this.hapChar.Active, 1)
+          this.accessory.log(`${platformLang.curState} [on]`)
+        }
         if (this.cacheSize !== mode) {
           this.cacheSize = mode
           this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSize)
@@ -182,6 +199,14 @@ export default class {
             this.service.updateCharacteristic(this.hapChar.Active, this.cacheState === 'on' ? 1 : 0)
             this.accessory.log(`${platformLang.curState} [${this.cacheState}]`)
           }
+          break
+        }
+        case 'aa05': {
+          // Ice size report. The payload encoding is deliberately NOT decoded here:
+          // sizeCodes runs small=0x03..large=0x01 while the OpenAPI path sends
+          // workMode un-inverted, and which is authoritative is unresolved (#1329).
+          // Claiming a mapping here could silently swap sizes, so this case exists
+          // only to stop a routine status report being logged as a new scene code.
           break
         }
         default:

--- a/lib/device/ice-maker-H717D.js
+++ b/lib/device/ice-maker-H717D.js
@@ -52,6 +52,13 @@ export default class {
       .onSet(async value => this.internalSizeUpdate(value))
     this.cacheSize = this.service.getCharacteristic(this.hapChar.RotationSpeed).value || 2
 
+    // Keep the characteristic in step with the cache. Without this an accessory
+    // that has never had a size set reports Active=1 with RotationSpeed=0, which
+    // is contradictory and which the Home app renders as "0".
+    if (this.service.getCharacteristic(this.hapChar.RotationSpeed).value !== this.cacheSize) {
+      this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSize)
+    }
+
     // Output the customised options to the log
     const opts = JSON.stringify({})
     platform.log('[%s] %s %s.', accessory.displayName, platformLang.devInitOpts, opts)
@@ -105,8 +112,15 @@ export default class {
 
   async internalSizeUpdate(value) {
     try {
-      // Don't continue if 0
+      // 0 is not a valid ice size. Put the slider back, otherwise HomeKit keeps 0
+      // while the device carries on at cacheSize - and that 0 is what gets written
+      // to the accessory cache, so it returns on the next restart. Deferred for the
+      // same reason as the error reverts below: an immediate update would be
+      // overwritten by the value HomeKit is currently writing.
       if (value === 0) {
+        setTimeout(() => {
+          this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSize)
+        }, 1000)
         return
       }
 
@@ -145,8 +159,11 @@ export default class {
     if (params.workMode) {
       const mode = params.workMode.workMode
       if (mode > 0 && mode <= 3) {
-        this.cacheState = 'on'
-        this.service.updateCharacteristic(this.hapChar.Active, 1)
+        if (this.cacheState !== 'on') {
+          this.cacheState = 'on'
+          this.service.updateCharacteristic(this.hapChar.Active, 1)
+          this.accessory.log(`${platformLang.curState} [on]`)
+        }
         if (this.cacheSize !== mode) {
           this.cacheSize = mode
           this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSize)
@@ -182,6 +199,14 @@ export default class {
             this.service.updateCharacteristic(this.hapChar.Active, this.cacheState === 'on' ? 1 : 0)
             this.accessory.log(`${platformLang.curState} [${this.cacheState}]`)
           }
+          break
+        }
+        case 'aa05': {
+          // Ice size report. The payload encoding is deliberately NOT decoded here:
+          // sizeCodes runs small=0x03..large=0x01 while the OpenAPI path sends
+          // workMode un-inverted, and which is authoritative is unresolved (#1329).
+          // Claiming a mapping here could silently swap sizes, so this case exists
+          // only to stop a routine status report being logged as a new scene code.
           break
         }
         default:

--- a/lib/device/ice-maker-H8120.js
+++ b/lib/device/ice-maker-H8120.js
@@ -52,6 +52,13 @@ export default class {
       .onSet(async value => this.internalSizeUpdate(value))
     this.cacheSize = this.service.getCharacteristic(this.hapChar.RotationSpeed).value || 2
 
+    // Keep the characteristic in step with the cache. Without this an accessory
+    // that has never had a size set reports Active=1 with RotationSpeed=0, which
+    // is contradictory and which the Home app renders as "0".
+    if (this.service.getCharacteristic(this.hapChar.RotationSpeed).value !== this.cacheSize) {
+      this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSize)
+    }
+
     // Output the customised options to the log
     const opts = JSON.stringify({})
     platform.log('[%s] %s %s.', accessory.displayName, platformLang.devInitOpts, opts)
@@ -105,8 +112,15 @@ export default class {
 
   async internalSizeUpdate(value) {
     try {
-      // Don't continue if 0
+      // 0 is not a valid ice size. Put the slider back, otherwise HomeKit keeps 0
+      // while the device carries on at cacheSize - and that 0 is what gets written
+      // to the accessory cache, so it returns on the next restart. Deferred for the
+      // same reason as the error reverts below: an immediate update would be
+      // overwritten by the value HomeKit is currently writing.
       if (value === 0) {
+        setTimeout(() => {
+          this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSize)
+        }, 1000)
         return
       }
 
@@ -145,8 +159,11 @@ export default class {
     if (params.workMode) {
       const mode = params.workMode.workMode
       if (mode > 0 && mode <= 3) {
-        this.cacheState = 'on'
-        this.service.updateCharacteristic(this.hapChar.Active, 1)
+        if (this.cacheState !== 'on') {
+          this.cacheState = 'on'
+          this.service.updateCharacteristic(this.hapChar.Active, 1)
+          this.accessory.log(`${platformLang.curState} [on]`)
+        }
         if (this.cacheSize !== mode) {
           this.cacheSize = mode
           this.service.updateCharacteristic(this.hapChar.RotationSpeed, this.cacheSize)
@@ -182,6 +199,14 @@ export default class {
             this.service.updateCharacteristic(this.hapChar.Active, this.cacheState === 'on' ? 1 : 0)
             this.accessory.log(`${platformLang.curState} [${this.cacheState}]`)
           }
+          break
+        }
+        case 'aa05': {
+          // Ice size report. The payload encoding is deliberately NOT decoded here:
+          // sizeCodes runs small=0x03..large=0x01 while the OpenAPI path sends
+          // workMode un-inverted, and which is authoritative is unresolved (#1329).
+          // Claiming a mapping here could silently swap sizes, so this case exists
+          // only to stop a routine status report being logged as a new scene code.
           break
         }
         default:

--- a/lib/utils/functions.js
+++ b/lib/utils/functions.js
@@ -106,9 +106,44 @@ function statusToActionCode(statusCode) {
   return Buffer.from(generatedCode, 'base64').toString('hex')
 }
 
+/**
+ * Convert a HomeKit RotationSpeed percentage into a device speed step.
+ *
+ * `steps` is the number of REAL speeds the model has, excluding auto (8 on the
+ * H7100 family, 12 on the H7105/H7107/H1370). A percentage of 0 means "off" and
+ * is handled by the caller, so this always returns a usable step in 1..steps.
+ *
+ * Auto is deliberately NOT reachable from here. Auto is a mode, not a speed, so
+ * 100% means maximum speed. Exposing auto at the top of the slider is what made
+ * the previous behaviour surprising - dragging to full would silently select
+ * auto instead of full power.
+ */
+function hkPercentToFanSpeed(percent, steps) {
+  return Math.max(1, Math.min(steps, Math.round((percent * steps) / 100)))
+}
+
+/**
+ * Convert a device speed step into a HomeKit RotationSpeed percentage.
+ *
+ * When the device reports auto, HomeKit is shown 100%, but callers should keep
+ * their own cache at `autoSpeed`. That lets the plugin tell "the device is in
+ * auto" apart from "the user asked for maximum speed", and so avoid echoing a
+ * redundant command straight back to the device.
+ */
+function fanSpeedToHkPercent(speed, steps, autoSpeed) {
+  if (autoSpeed !== undefined && speed === autoSpeed) {
+    return 100
+  }
+  if (!speed || speed < 1) {
+    return 0
+  }
+  return Math.min(100, Math.round((speed / steps) * 100))
+}
+
 export {
   base64ToHex,
   cenToFar,
+  fanSpeedToHkPercent,
   farToCen,
   generateCodeFromHexValues,
   generateRandomString,
@@ -117,6 +152,7 @@ export {
   hexToBase64,
   hexToDecimal,
   hexToTwoItems,
+  hkPercentToFanSpeed,
   nearestHalf,
   parseDeviceId,
   parseError,


### PR DESCRIPTION
Implements fixes 1 and 2 from #1329, plus the two minor items you were happy to take along.

## Scope

**All three ice-maker modules.** They are byte-identical (same md5, `diff` empty), so I applied the same change to each rather than factoring out a shared module — you asked for whichever diff reads easiest, and three copies of a small change reads better than a structural refactor. Happy to do the extraction as a separate PR if you'd rather; they're identical today, so it would be clean.

## What's in

**1. Reconcile the characteristic with the cache at init.** The seed used `.value || 2` and never wrote the fallback back, so `cacheSize` became 2 while the characteristic stayed 0.

**2. Put the slider back when a 0 is swallowed.** `internalSizeUpdate` returned early on 0 with no revert, so HomeKit kept 0 while the device carried on — and that 0 was what got persisted to the accessory cache, regenerating the stale value on the next restart. So fix 1 alone wouldn't have held.

The revert is deferred by 1s rather than immediate. Same reason your error reverts use `setTimeout`: an immediate `updateCharacteristic` on the characteristic currently being written gets overwritten by HomeKit's own value. I used 1s rather than your 2s because this isn't an error path and 2s of showing "0" felt long — say the word if you'd rather it matched.

**3. Guard the `Active` write** in the OpenAPI branch, matching its sibling branches which all check before writing and log the transition.

**4. Give the size status report its own case** so it stops falling through to the `new scene code` warning on every report.

## What's deliberately out

**The size-code inversion.** Left exactly as you asked. The new `aa05` case does **not** decode the payload, and says so in a comment — claiming a mapping there is precisely the "silently swap ice sizes for everyone" risk you flagged. If I get a chance to watch the device respond to each size over both transports, I'll open that separately with evidence.

**`showAs`** — declined upstream, not touched.

**`heater1a.js` / `heater1b.js`.** You offered, and I'm passing: I don't own a heater, so I can't test the change. I'd rather not put a fix in your codebase for a device class I can't exercise. The instances are at `heater1a.js:236` and `heater1b.js:452` if you or someone with the hardware wants them.

## Testing

`npm run lint` passes clean across the repo. All three modules parse, and remain byte-identical to each other after the change.

**Hardware:** I have an H8120 and will confirm the tile stops reading "0" once this is in a beta. **Not** hardware-tested for H7172 or H717D — but since the files are identical, testing H8120 exercises the same code.

One flag on the `aa05` case: I inferred that code by symmetry with the `33 05` set command, since `deviceFunction` is always `aa` plus the second byte. If a size report actually arrives under a different code, that case needs renaming and the warning will keep firing — worth a second pair of eyes from someone who's seen the traffic.