### PR TITLE
feat: ble encryption for the H3001 solar string lights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `@homebridge-plugins/homebridge-govee` will be documented
 ### Changed
 
 - fix: stop shipping the test files to npm, since they are only needed in the repository
+- feat: add ble encryption for the H3001 solar string lights, which silently ignore unencrypted frames (#1328)
 
 ## v11.32.1 (2026-08-02)
 

--- a/lib/connection/ble.js
+++ b/lib/connection/ble.js
@@ -3,8 +3,10 @@ import process from 'node:process'
 
 import btClient from '@stoprocent/noble'
 
+import { buildHandshake, isHandshakeFrame, parseHandshakeResponse, V2Session } from '../utils/ble-crypto.js'
 import { BLE_STAGE_TIMEOUTS, UUID } from '../utils/ble-protocol.js'
 import { decodeAny } from '../utils/decode.js'
+import { getDeviceCapabilities } from '../utils/device-capabilities.js'
 import { base64ToHex, generateCodeFromHexValues, hexToTwoItems, sleep } from '../utils/functions.js'
 import platformLang from '../utils/lang-en.js'
 import { isValidPeripheral } from '../utils/validation.js'
@@ -19,6 +21,7 @@ const H5101_UUID = '0001'
 const POWER_ON_TIMEOUT = BLE_STAGE_TIMEOUTS.powerOn
 const CONNECTION_TIMEOUT = BLE_STAGE_TIMEOUTS.connect
 const WRITE_TIMEOUT = BLE_STAGE_TIMEOUTS.write
+const HANDSHAKE_TIMEOUT = BLE_STAGE_TIMEOUTS.handshake
 const SETTLE_DELAY = BLE_STAGE_TIMEOUTS.settle
 
 /*
@@ -240,8 +243,19 @@ export default class BLEConnection {
       const finalBuffer = this.prepareCommandBuffer(params)
       accessory.logDebug(`sending command: ${finalBuffer.toString('hex')}`)
 
+      // Encrypted models refuse the plain frame. Because writes are
+      // unacknowledged, they refuse it silently, so the handshake has to happen
+      // here rather than being discovered by a failed write. It is per
+      // connection: the frame counter resets with the link.
+      let payload = finalBuffer
+      if (getDeviceCapabilities(accessory.context.gvModel).bleEncryption === 'v2') {
+        const session = await this.negotiateSession(accessory, characteristic, characteristics)
+        payload = session.seal(finalBuffer)
+        accessory.logDebug(`encrypted as: ${payload.toString('hex')}`)
+      }
+
       // Write without response then allow time for the BLE controller to transmit before disconnecting
-      await this.writeWithTimeout(characteristic, finalBuffer, WRITE_TIMEOUT)
+      await this.writeWithTimeout(characteristic, payload, WRITE_TIMEOUT)
       accessory.logDebug('command sent successfully')
       await sleep(SETTLE_DELAY)
     } catch (err) {
@@ -271,6 +285,70 @@ export default class BLEConnection {
           )
         }, 1000)
       }
+    }
+  }
+
+  /**
+   * Exchange a session key with an encrypted model.
+   *
+   * Unlike every other path in this client we need a reply, which arrives as a
+   * notification on UUID.NOTIFY. Note that we deliberately do NOT subscribe:
+   * these lights push notifications without the client ever writing the client
+   * characteristic configuration descriptor, exactly as the official app does.
+   * Calling subscribeAsync() here makes the descriptor write hang and the light
+   * then drops the connection, so listening is both sufficient and required.
+   *
+   * The reply is authenticated - parseHandshakeResponse throws if the GCM tag
+   * does not verify - which turns a wrong key into a real error rather than a
+   * light that silently ignores every command.
+   *
+   * Returns a V2Session that wraps outgoing frames.
+   */
+  async negotiateSession(accessory, writeCharacteristic, characteristics) {
+    const notifyCharacteristic = Object.values(characteristics).find(
+      char => char.uuid.replace(HYPHEN_REGEX, '') === UUID.NOTIFY,
+    )
+    if (!notifyCharacteristic) {
+      throw new Error('Notify characteristic not found, cannot negotiate encryption')
+    }
+
+    let resolveReply
+    let rejectReply
+    const reply = new Promise((resolve, reject) => {
+      resolveReply = resolve
+      rejectReply = reject
+    })
+    // Attach a handler immediately: if the write below throws, the timeout would
+    // otherwise reject an unawaited promise and crash the process.
+    reply.catch(() => {})
+
+    const onData = (data) => {
+      // The light also pushes state frames here; take only the handshake.
+      if (isHandshakeFrame(data)) {
+        resolveReply(data)
+      }
+    }
+    notifyCharacteristic.on('data', onData)
+    const timer = setTimeout(
+      () => rejectReply(new Error('Encryption handshake timeout')),
+      HANDSHAKE_TIMEOUT,
+    )
+
+    try {
+      const { frame, txIvKey } = buildHandshake()
+      accessory.logDebug(`sending handshake: ${frame.toString('hex')}`)
+      await this.writeWithTimeout(writeCharacteristic, frame, WRITE_TIMEOUT)
+
+      const response = await reply
+      accessory.logDebug(`handshake reply: ${response.toString('hex')}`)
+
+      const { devInfo, sku, mac } = parseHandshakeResponse(response)
+      accessory.logDebug(`handshake verified for ${sku} at ${mac}`)
+
+      return new V2Session({ txIvKey, devInfo })
+    } finally {
+      clearTimeout(timer)
+      notifyCharacteristic.removeListener('data', onData)
     }
   }
 

--- a/lib/utils/ble-crypto.js
+++ b/lib/utils/ble-crypto.js
@@ -1,0 +1,130 @@
+/**
+ * Govee "V2" BLE encryption (EncryptionManagerV2 in the Govee Home app).
+ *
+ * Used by newer Bluetooth-only devices such as the H3001 solar string lights.
+ * Older devices take the plain 20-byte frame; these wrap it in AES-128-GCM and
+ * silently ignore anything that is not wrapped.
+ *
+ * Wire format on 00010203-0405-0607-0809-0a0b0c0d2b11 (write) and ...2b10 (notify):
+ *
+ *   handshake request   e7 11 01 | iv(12) | tagLen(1) | GCM{ txIvKey(8) }
+ *                       AAD = frame[0..15]                     key = KEY_HANDSHAKE
+ *   handshake response  e7 11 00 | iv(12) |            GCM{ rxIvKey(8) ++ devInfo(11) }
+ *                       AAD = frame[0..14]                     key = KEY_HANDSHAKE
+ *
+ *   deviceKey = AES-128-ECB-encrypt(KEY_DEVICE, devInfo ++ 00*5)
+ *
+ *   data frame          counter(4, big endian) | GCM{ 20-byte Govee frame }
+ *                       nonce = txIvKey(8) ++ counter(4)
+ *                       AAD   = counter(4)
+ *                       key   = deviceKey
+ *                       tag   = 12 bytes appended
+ *
+ * devInfo is the ASCII SKU (5 bytes, e.g. "H3001") followed by the MAC address
+ * in reverse byte order, so the per-device key needs no cloud lookup.
+ *
+ * Counters are per-direction, start at 1, and increment by one per frame. They
+ * reset on every connection, so a handshake is required per connection.
+ *
+ * No new dependencies: node:crypto provides aes-128-gcm and aes-128-ecb.
+ */
+import { Buffer } from 'node:buffer'
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto'
+
+// Application-wide constants, recovered from the Govee Home app's string
+// resources (LibTools KEY_COMMUNICATION_X / _Y).
+const KEY_HANDSHAKE = Buffer.from('fc03783c7c42cb83e202a1643648aff6', 'hex')
+const KEY_DEVICE = Buffer.from('ae028b630bae6ecc4bff1b249e22f955', 'hex')
+
+const TAG_LEN = 12 // 96-bit tag; the app falls back to 128-bit
+const HDR = { MAGIC0: 0xE7, MAGIC1: 0x11, SUB_REQUEST: 0x01, STATUS_OK: 0x00 }
+
+/** True if `data` is an e711 handshake frame rather than a data frame. */
+export function isHandshakeFrame(data) {
+  return data.length >= 3 && data[0] === HDR.MAGIC0 && data[1] === HDR.MAGIC1
+}
+
+function gcmSeal(key, iv, aad, plaintext) {
+  const c = createCipheriv('aes-128-gcm', key, iv, { authTagLength: TAG_LEN })
+  c.setAAD(aad)
+  return Buffer.concat([c.update(plaintext), c.final(), c.getAuthTag()])
+}
+
+function gcmOpen(key, iv, blob, aad) {
+  const d = createDecipheriv('aes-128-gcm', key, iv, { authTagLength: TAG_LEN })
+  d.setAAD(aad)
+  d.setAuthTag(blob.subarray(blob.length - TAG_LEN))
+  return Buffer.concat([d.update(blob.subarray(0, blob.length - TAG_LEN)), d.final()]) // throws on a bad tag
+}
+
+/**
+ * Build the handshake to write first on every new connection.
+ * Returns { frame, txIvKey } -- keep txIvKey, it seeds the nonce for writes.
+ */
+export function buildHandshake(txIvKey = randomBytes(8), iv = randomBytes(12)) {
+  const frame = Buffer.alloc(36)
+  frame[0] = HDR.MAGIC0
+  frame[1] = HDR.MAGIC1
+  frame[2] = HDR.SUB_REQUEST
+  iv.copy(frame, 3)
+  frame[15] = TAG_LEN
+  gcmSeal(KEY_HANDSHAKE, iv, frame.subarray(0, 16), txIvKey).copy(frame, 16)
+  return { frame, txIvKey }
+}
+
+/**
+ * Parse the light's handshake reply. Returns { rxIvKey, devInfo, sku, mac }.
+ * Throws if the GCM tag does not verify or the device reports an error status.
+ */
+export function parseHandshakeResponse(frame) {
+  if (!isHandshakeFrame(frame)) {
+    throw new Error(`not an e711 response: ${frame.subarray(0, 4).toString('hex')}`)
+  }
+  if (frame[2] !== HDR.STATUS_OK) {
+    throw new Error(`handshake rejected, status 0x${frame[2].toString(16)}`)
+  }
+  // Note the AAD here is 15 bytes: the reply carries no tag-length byte.
+  const blob = gcmOpen(KEY_HANDSHAKE, frame.subarray(3, 15), frame.subarray(15), frame.subarray(0, 15))
+  if (blob.length !== 19) {
+    throw new Error(`expected a 19-byte handshake blob, got ${blob.length}`)
+  }
+  const devInfo = blob.subarray(8, 19)
+  return {
+    rxIvKey: blob.subarray(0, 8),
+    devInfo,
+    sku: devInfo.subarray(0, 5).toString('ascii'),
+    mac: Buffer.from(devInfo.subarray(5, 11)).reverse().toString('hex').replace(/(..)(?=.)/g, '$1:'),
+  }
+}
+
+/** deviceKey = AES-128-ECB-encrypt(KEY_DEVICE, devInfo padded to 16 with zeros). */
+function deriveDeviceKey(devInfo) {
+  const block = Buffer.alloc(16)
+  devInfo.copy(block)
+  const c = createCipheriv('aes-128-ecb', KEY_DEVICE, null)
+  c.setAutoPadding(false)
+  return Buffer.concat([c.update(block), c.final()])
+}
+
+/** Per-connection session, wrapping outgoing 20-byte frames. */
+export class V2Session {
+  constructor({ txIvKey, devInfo }) {
+    this.txIvKey = txIvKey
+    this.deviceKey = deriveDeviceKey(devInfo)
+    this.txCounter = 1
+  }
+
+  /** Wrap a plain 20-byte Govee frame for writing. */
+  seal(frame20, counter = this.txCounter) {
+    const ctr = Buffer.alloc(4)
+    ctr.writeUInt32BE(counter >>> 0, 0)
+    const out = Buffer.concat([
+      ctr,
+      gcmSeal(this.deviceKey, Buffer.concat([this.txIvKey, ctr]), ctr, frame20),
+    ])
+    if (counter === this.txCounter) {
+      this.txCounter += 1
+    }
+    return out
+  }
+}

--- a/lib/utils/ble-crypto.test.js
+++ b/lib/utils/ble-crypto.test.js
@@ -1,0 +1,119 @@
+import { Buffer } from 'node:buffer'
+
+import { describe, expect, it } from 'vitest'
+
+import { buildHandshake, isHandshakeFrame, parseHandshakeResponse, V2Session } from './ble-crypto.js'
+import { BLE_STAGE_TIMEOUTS, BLE_UPDATE_TIMEOUT } from './ble-protocol.js'
+import { getDeviceCapabilities } from './device-capabilities.js'
+
+/**
+ * Vectors below are real frames captured from the official Govee app driving an
+ * H3001, so these tests pin the implementation to observed device behaviour
+ * rather than to itself.
+ */
+const HS_REQUEST = Buffer.from('e711010e02e79909b331d0601c9d370cfa8a05bc90a0ff9095c658d69f9c03c63a5f6d5d', 'hex')
+const HS_RESPONSE = Buffer.from('e711004b42365199783477c70e12fd47c4b550a8f903b75415181afbe40044fd3ccccf0a5d5d878c04774f32d1de', 'hex')
+const TX_IV_KEY = Buffer.from('636a4c22846bbcf8', 'hex')
+const DEV_INFO = Buffer.from('48333030310f97dfc1c4fb', 'hex')
+const DATA_FRAME = Buffer.from('00000001a99194e788ebeaf1d31d1600c05f61298b38e21dcfa0fdb0976cb57c9a10f11a', 'hex')
+const DATA_PLAIN = Buffer.from('33090b010c0701fc000208ea07b85b6f6a0000c7', 'hex')
+
+describe('bLE v2 handshake', () => {
+  it('rebuilds the captured request byte for byte', () => {
+    // Same ivKey and same GCM iv as the capture, so the output must match
+    // exactly - this is what proves the AAD and layout are right.
+    const { frame } = buildHandshake(TX_IV_KEY, HS_REQUEST.subarray(3, 15))
+    expect(frame.toString('hex')).toBe(HS_REQUEST.toString('hex'))
+    expect(frame).toHaveLength(36)
+    expect(frame[15]).toBe(12) // declared tag length
+  })
+
+  it('generates a fresh key and iv each call', () => {
+    const a = buildHandshake()
+    const b = buildHandshake()
+    expect(a.txIvKey.toString('hex')).not.toBe(b.txIvKey.toString('hex'))
+    expect(a.frame.toString('hex')).not.toBe(b.frame.toString('hex'))
+  })
+
+  it('extracts the device identity from the reply', () => {
+    const { devInfo, sku, mac } = parseHandshakeResponse(HS_RESPONSE)
+    expect(devInfo.toString('hex')).toBe(DEV_INFO.toString('hex'))
+    expect(sku).toBe('H3001')
+    expect(mac).toBe('fb:c4:c1:df:97:0f')
+  })
+
+  it('rejects a reply whose authentication tag does not verify', () => {
+    const tampered = Buffer.from(HS_RESPONSE)
+    tampered[20] ^= 0x01
+    expect(() => parseHandshakeResponse(tampered)).toThrow()
+  })
+
+  it('reports a non-zero status byte rather than trying to decrypt', () => {
+    const rejected = Buffer.from(HS_RESPONSE)
+    rejected[2] = 0x02
+    expect(() => parseHandshakeResponse(rejected)).toThrow(/status/)
+  })
+
+  it('tells a handshake frame apart from a data frame', () => {
+    expect(isHandshakeFrame(HS_REQUEST)).toBe(true)
+    expect(isHandshakeFrame(HS_RESPONSE)).toBe(true)
+    expect(isHandshakeFrame(DATA_FRAME)).toBe(false)
+    expect(isHandshakeFrame(Buffer.from('e7', 'hex'))).toBe(false)
+  })
+
+  it('has its own timeout stage, inside the overall update budget', () => {
+    expect(BLE_STAGE_TIMEOUTS.handshake).toBeGreaterThan(0)
+    expect(BLE_UPDATE_TIMEOUT).toBeGreaterThan(
+      BLE_STAGE_TIMEOUTS.connect + BLE_STAGE_TIMEOUTS.handshake + BLE_STAGE_TIMEOUTS.write,
+    )
+  })
+})
+
+describe('bLE v2 session', () => {
+  const session = () => new V2Session({ txIvKey: TX_IV_KEY, devInfo: DEV_INFO })
+
+  it('seals a command into the exact bytes the app sent', () => {
+    // Matching the capture here also proves the device key derivation, since a
+    // wrong key cannot produce these bytes.
+    expect(session().seal(DATA_PLAIN, 1).toString('hex')).toBe(DATA_FRAME.toString('hex'))
+  })
+
+  it('numbers frames from one and increments per command', () => {
+    const s = session()
+    expect(s.seal(DATA_PLAIN).readUInt32BE(0)).toBe(1)
+    expect(s.seal(DATA_PLAIN).readUInt32BE(0)).toBe(2)
+    expect(s.seal(DATA_PLAIN).readUInt32BE(0)).toBe(3)
+  })
+
+  it('never repeats a nonce, so identical commands look different on air', () => {
+    const s = session()
+    expect(s.seal(DATA_PLAIN).toString('hex')).not.toBe(s.seal(DATA_PLAIN).toString('hex'))
+  })
+
+  it('adds 16 bytes of overhead: 4 counter plus a 12 byte tag', () => {
+    expect(session().seal(DATA_PLAIN)).toHaveLength(DATA_PLAIN.length + 16)
+  })
+})
+
+describe('h3001 capabilities', () => {
+  it('selects the encrypted transport, and leaves every other model alone', () => {
+    expect(getDeviceCapabilities('H3001').bleEncryption).toBe('v2')
+    expect(getDeviceCapabilities('H6199').bleEncryption).toBe(false)
+    expect(getDeviceCapabilities('H615B').bleEncryption).toBe(false)
+    expect(getDeviceCapabilities('unknown-model').bleEncryption).toBe(false)
+  })
+
+  it('builds the colour frame the light actually accepts', () => {
+    // Mirrors buildColorCommand: [...bleColorCmd, r, g, b, ...suffix]
+    const caps = getDeviceCapabilities('H3001')
+    const data = [...caps.bleColorCmd, 0xFF, 0x00, 0x00, ...caps.bleColorCmdSuffix]
+    expect(Buffer.from([0x33, 0x05, ...data]).toString('hex'))
+      .toBe('33051501ff00000000000000ff')
+  })
+
+  it('scales brightness to the 0-100 range this model expects', () => {
+    const { bleBrightnessScale } = getDeviceCapabilities('H3001')
+    expect(Math.floor((30 / 100) * bleBrightnessScale)).toBe(0x1E)
+    expect(Math.floor((100 / 100) * bleBrightnessScale)).toBe(0x64)
+  })
+})

--- a/lib/utils/ble-protocol.js
+++ b/lib/utils/ble-protocol.js
@@ -57,6 +57,9 @@ export const UUID = {
   SERVICE: '00010203-0405-0607-0809-0a0b0c0d1910',
   WRITE_DEFAULT: '000102030405060708090a0b0c0d2b11',
   WRITE_ALT: '000102030405060708090a0b0c0d2b10', // H615B
+  // The same attribute as WRITE_ALT, named for the role it plays on encrypted
+  // models: they answer the key handshake here.
+  NOTIFY: '000102030405060708090a0b0c0d2b10',
 }
 
 // Total BLE packet size
@@ -70,6 +73,11 @@ export const BLE_STAGE_TIMEOUTS = {
   powerOn: 5000,
   connect: 10000,
   write: 5000,
+  // Encrypted models exchange a session key before the first real command (see
+  // ble-crypto.js). Captures of the official app show the light replying in
+  // about 30ms, so this is a generous ceiling rather than an expected cost.
+  // Models that need no handshake never spend any of it.
+  handshake: 5000,
   settle: 100, // let the controller transmit before disconnecting
 
   // Discovering services, and the disconnect on the way out, have no timeout of

--- a/lib/utils/device-capabilities.js
+++ b/lib/utils/device-capabilities.js
@@ -35,6 +35,21 @@ const modelOverrides = {
   // H615B uses alternate BLE write characteristic UUID
   H615B: { bleWriteUuid: UUID.WRITE_ALT },
 
+  // Bluetooth-only solar string lights (#1328). Every frame is wrapped in
+  // AES-128-GCM, so this model needs the key handshake in ble-crypto.js before
+  // any command is accepted. Its colour and brightness formats were read off a
+  // capture of the official app:
+  //   colour     33 05 15 01 RR GG BB 00 00 00 00 00 FF  (then zero padding)
+  //   brightness 33 04 <0-100>          e.g. 0x1e for 30%, 0x64 for 100%
+  // Writes are unacknowledged, so without the wrapper the light silently
+  // ignores everything and the plugin cannot tell.
+  H3001: {
+    bleEncryption: 'v2',
+    bleColorCmd: COLOR_SUB.RGB_EXTENDED,
+    bleColorCmdSuffix: [0x00, 0x00, 0x00, 0x00, 0x00, 0xFF],
+    bleBrightnessScale: 0x64,
+  },
+
   // H6121 requires cmdVersion 1 for status requests
   H6121: { awsStatusCmdVersion: 1 },
 
@@ -57,6 +72,9 @@ const defaults = {
   bleWriteUuid: UUID.WRITE_DEFAULT,
   awsStatusCmdVersion: 2,
   awsBrightnessNoScale: false,
+  // false for the great majority of models, which take the plain 20-byte frame.
+  // 'v2' selects the AES-128-GCM transport in ble-crypto.js.
+  bleEncryption: false,
 }
 
 export function getDeviceCapabilities(model) {


### PR DESCRIPTION
Adds the AES-128-GCM BLE transport that newer bluetooth-only Govee models require, and enables it for the H3001 solar string lights. Refs #1328.

The H3001 is bluetooth-only and wraps every frame. Because BLE writes on this path are unacknowledged, an unwrapped frame is discarded silently, so today the plugin reports success while the light does nothing.

### Changes

- `lib/utils/ble-crypto.js` (new) — session handshake, per-device key derived from SKU + MAC, frame sealing. `node:crypto` only, no new dependencies, no cloud lookup.
- `lib/connection/ble.js` — handshake once per connection, then seal before the write. Gated on a capability flag, so the plain-frame path every other model uses is unchanged.
- `lib/utils/device-capabilities.js` — `bleEncryption` defaults to `false`. The H3001 entry also carries its colour format and its 0-100 brightness scale, which differ from the defaults.
- `lib/utils/ble-protocol.js` — the notify characteristic UUID, and a `handshake` stage in the timeout budget so the extra round trip cannot eat the write allowance.

### Protocol notes

The keys are two app-wide constants recovered from the Govee Home app's string resources. The per-device key is `AES-128-ECB(KEY_DEVICE, SKU ++ reversed MAC)`, so no account or cloud call is needed. Frame counters are per-direction and reset with the link, which is why the handshake runs per connection.

One thing worth flagging for anyone extending this: the light answers the handshake on `...2b10` without the client ever writing the CCCD. Calling `subscribeAsync()` there makes the descriptor write hang and the light then drops the connection, so the implementation attaches a `data` listener instead. The official app behaves the same way — its capture contains no CCCD write.

### Testing

Tests are pinned to frames captured from the official app driving a real H3001, so they rebuild the handshake request and a sealed command byte for byte rather than testing the implementation against itself. A wrong device key cannot produce those bytes, which is what makes the derivation testable without hardware.

`npm test` passes. Verified live on hardware: power on/off, brightness at 100 and 30, and colour. Handshake takes about 45ms.

### Not included

- No state read-back, so HomeKit state stays optimistic for this model.
- Unrelated but visible when testing this: on a host where `bluetoothd` shares the adapter, roughly one connect in six fails with `Command Disallowed (0xc)` inside `connectWithTimeout`, before any of this code runs. It reproduces without these changes and a retry clears it. Happy to raise that separately.
