### PR TITLE
fix: BLE device control on macOS by resolving peripherals via advertised name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `@homebridge-plugins/homebridge-govee` will be documented
 ### Changed
 
 - fix: stop shipping the test files to npm, since they are only needed in the repository
+- fix: BLE device control on macOS, by resolving peripherals via their advertised local name (CoreBluetooth never exposes MAC addresses, so the existing connect-by-address path could never succeed on darwin)
 
 ## v11.32.1 (2026-08-02)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Homebridge plugin to integrate Govee devices into HomeKit
 - To use this plugin, you will need to already have:
   - [Node](https://nodejs.org): latest version of `v22`, `v24` or `v26` - any other major version is not supported.
   - [Homebridge](https://homebridge.io): `v1.6` or above - refer to link for more information and installation instructions.
-  - For bluetooth connectivity, it may be necessary to install extra packages on your system, see [Bluetooth Control](https://github.com/homebridge-plugins/homebridge-govee/wiki/Bluetooth-Control). Bluetooth works best when using a Raspberry Pi, not been tested on Windows, and Mac devices are unsupported.
+  - For bluetooth connectivity, it may be necessary to install extra packages on your system, see [Bluetooth Control](https://github.com/homebridge-plugins/homebridge-govee/wiki/Bluetooth-Control). Bluetooth works best when using a Raspberry Pi, and has not been tested on Windows. On macOS, the plugin resolves BLE devices via their advertised name (macOS does not expose bluetooth MAC addresses), and the `node` binary running Homebridge needs Bluetooth permission in System Settings → Privacy & Security → Bluetooth.
 
 ### Setup
 

--- a/lib/connection/ble.js
+++ b/lib/connection/ble.js
@@ -278,7 +278,9 @@ export default class BLEConnection {
     let timeoutId
     try {
       return await Promise.race([
-        btClient.connectAsync(address),
+        process.platform === 'darwin'
+          ? this.connectByNameDarwin(address, timeout)
+          : btClient.connectAsync(address),
         new Promise((_, reject) => {
           timeoutId = setTimeout(() => reject(new Error('Connection timeout')), timeout)
         }),
@@ -286,6 +288,49 @@ export default class BLEConnection {
     } finally {
       clearTimeout(timeoutId)
     }
+  }
+
+  // macOS: CoreBluetooth never exposes MAC addresses, so connect-by-address can
+  // never resolve. Govee devices advertise a local name whose suffix is the last
+  // two bytes of their MAC (e.g. Govee_H617A_325A for ...:32:5A), so scan and
+  // match on that instead, then connect to the discovered peripheral directly.
+  async connectByNameDarwin(address, timeout) {
+    const suffix = address.replace(/:/g, '').slice(-4).toLowerCase()
+    this.darwinPeripheralCache = this.darwinPeripheralCache ?? new Map()
+    const cached = this.darwinPeripheralCache.get(suffix)
+    if (cached) {
+      try {
+        await cached.connectAsync()
+        return cached
+      } catch (err) {
+        this.darwinPeripheralCache.delete(suffix)
+        this.log.debug('[BLE] cached peripheral for %s failed (%s), rescanning.', suffix, err.message)
+      }
+    }
+    const peripheral = await new Promise((resolve, reject) => {
+      let done = false
+      function onDiscover(p) {
+        const name = (p.advertisement?.localName ?? '').toLowerCase()
+        if (name.endsWith(suffix) && (name.startsWith('govee') || name.startsWith('ihoment'))) {
+          finish(resolve, p)
+        }
+      }
+      function finish(fn, value) {
+        if (done) {
+          return
+        }
+        done = true
+        btClient.removeListener('discover', onDiscover)
+        btClient.stopScanningAsync().catch(() => {})
+        fn(value)
+      }
+      btClient.on('discover', onDiscover)
+      btClient.startScanningAsync([], true).catch(err => finish(reject, err))
+      setTimeout(() => finish(reject, new Error(`no peripheral advertising name suffix ${suffix} found in scan`)), Math.max(timeout - 1000, 4000))
+    })
+    this.darwinPeripheralCache.set(suffix, peripheral)
+    await peripheral.connectAsync()
+    return peripheral
   }
 
   async writeWithTimeout(characteristic, buffer, timeout) {

--- a/lib/connection/ble.test.js
+++ b/lib/connection/ble.test.js
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The bug these guard against: on macOS, CoreBluetooth never exposes peripheral
+ * MAC addresses, so noble's connect-by-address can never resolve and every BLE
+ * update fails with 'Invalid peripheral ID or Address'. Govee devices advertise
+ * a local name whose suffix is the last two bytes of their MAC (e.g.
+ * Govee_H617A_325A for ...:32:5A), so on darwin the plugin resolves peripherals
+ * by scanning for that suffix instead and connects to the discovered object.
+ */
+
+const btClient = vi.hoisted(() => {
+  const { EventEmitter: EE } = require('node:events')
+  const client = new EE()
+  client.startScanningAsync = vi.fn(async () => {})
+  client.stopScanningAsync = vi.fn(async () => {})
+  client.waitForPoweredOnAsync = vi.fn(async () => {})
+  client.connectAsync = vi.fn(async () => {})
+  client.reset = vi.fn()
+  return client
+})
+
+vi.mock('@stoprocent/noble', () => ({ default: btClient }))
+
+const { default: BLEConnection } = await import('./ble.js')
+
+function fakePeripheral(localName) {
+  return {
+    advertisement: { localName },
+    connectAsync: vi.fn(async () => {}),
+  }
+}
+
+function fakePlatform() {
+  return {
+    log: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  }
+}
+
+describe('connectByNameDarwin', () => {
+  let connection
+
+  beforeEach(() => {
+    btClient.removeAllListeners()
+    btClient.startScanningAsync.mockClear()
+    btClient.stopScanningAsync.mockClear()
+    connection = new BLEConnection(fakePlatform())
+  })
+
+  it('resolves the peripheral whose advertised name ends with the address suffix', async () => {
+    const strip = fakePeripheral('Govee_H617A_325A')
+    const promise = connection.connectByNameDarwin('db:48:c2:06:32:5a', 10000)
+
+    // Peripherals that must be ignored: different device, non-Govee vendor
+    btClient.emit('discover', fakePeripheral('ihoment_H6008_F409'))
+    btClient.emit('discover', fakePeripheral('NotAGovee_325A'))
+    btClient.emit('discover', strip)
+
+    await expect(promise).resolves.toBe(strip)
+    expect(strip.connectAsync).toHaveBeenCalledOnce()
+    expect(btClient.stopScanningAsync).toHaveBeenCalled()
+  })
+
+  it('matches case-insensitively, since bleAddress casing varies', async () => {
+    const strip = fakePeripheral('govee_h617a_325a')
+    const promise = connection.connectByNameDarwin('DB:48:C2:06:32:5A', 10000)
+
+    btClient.emit('discover', strip)
+
+    await expect(promise).resolves.toBe(strip)
+  })
+
+  it('accepts ihoment-prefixed names, which Govee bulbs advertise', async () => {
+    const bulb = fakePeripheral('ihoment_H6008_F409')
+    const promise = connection.connectByNameDarwin('aa:bb:cc:dd:f4:09', 10000)
+
+    btClient.emit('discover', bulb)
+
+    await expect(promise).resolves.toBe(bulb)
+  })
+
+  it('reuses a cached peripheral without scanning again', async () => {
+    const strip = fakePeripheral('Govee_H617A_325A')
+    const first = connection.connectByNameDarwin('db:48:c2:06:32:5a', 10000)
+    btClient.emit('discover', strip)
+    await first
+
+    btClient.startScanningAsync.mockClear()
+    await expect(connection.connectByNameDarwin('db:48:c2:06:32:5a', 10000)).resolves.toBe(strip)
+    expect(btClient.startScanningAsync).not.toHaveBeenCalled()
+    expect(strip.connectAsync).toHaveBeenCalledTimes(2)
+  })
+
+  it('rescans when the cached peripheral no longer connects', async () => {
+    // A peripheral object can go stale (device rebooted, adapter reset). The
+    // cache must not wedge the device forever - a failed connect evicts it and
+    // falls back to a fresh scan.
+    const stale = fakePeripheral('Govee_H617A_325A')
+    const first = connection.connectByNameDarwin('db:48:c2:06:32:5a', 10000)
+    btClient.emit('discover', stale)
+    await first
+
+    stale.connectAsync.mockRejectedValueOnce(new Error('Peripheral already gone'))
+    const fresh = fakePeripheral('Govee_H617A_325A')
+    const retry = connection.connectByNameDarwin('db:48:c2:06:32:5a', 10000)
+    await Promise.resolve()
+    await Promise.resolve()
+    btClient.emit('discover', fresh)
+
+    await expect(retry).resolves.toBe(fresh)
+  })
+
+  it('rejects when no matching peripheral appears before the scan timeout', async () => {
+    vi.useFakeTimers()
+    try {
+      const promise = connection.connectByNameDarwin('db:48:c2:06:32:5a', 10000)
+      const assertion = expect(promise).rejects.toThrow(/no peripheral advertising name suffix 325a/)
+
+      btClient.emit('discover', fakePeripheral('ihoment_H6008_D34D'))
+      await vi.advanceTimersByTimeAsync(9500)
+
+      await assertion
+      expect(btClient.stopScanningAsync).toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})


### PR DESCRIPTION
## Problem

BLE device control has never worked on macOS — the README has said "Mac devices are unsupported" since November 2021. BLE-only models (e.g. the H617A RGBIC strip, which supports neither AWS nor LAN) are completely uncontrollable from a Mac.

**Root cause:** CoreBluetooth never exposes peripheral MAC addresses. The plugin connects with `btClient.connectAsync(accessory.context.bleAddress)` (a MAC address), which can never resolve on darwin — noble's address→id map never gets populated, so every attempt throws:

```
[RGBIC Strip Lights] BLE update failed: Invalid peripheral ID or Address db:48:c2:06:32:5a.
    at Noble._getPeripheralId (@stoprocent/noble/lib/noble.js:382:15)
```

## Fix

Govee devices advertise a local name whose suffix is the last two bytes of their MAC — e.g. `Govee_H617A_325A` for a device whose `bleAddress` ends in `...:32:5A`, `ihoment_H6008_XXXX` for bulbs. The plugin already knows the MAC, so on darwin we can:

1. Scan and match a discovered peripheral whose advertised name starts with `govee`/`ihoment` and ends with the 4-hex suffix of the target address.
2. Connect to the discovered peripheral object directly (bypassing connect-by-address).
3. Cache resolved peripherals per suffix, with a rescan fallback if a cached peripheral fails to connect.

Linux/Windows keep the existing connect-by-address path — the new path is gated on `process.platform === 'darwin'`.

Also updates the README (macOS is now supported, with a note that the `node` binary needs Bluetooth permission under System Settings → Privacy & Security → Bluetooth) and adds a CHANGELOG entry under the pending release.

## Testing

Tested on a Mac mini M4 — macOS 27.0, node 24.18.1, Homebridge 2.2.1 (hb-service), plugin v11.32.1 — with an H617A (BLE-only) and 7× H6008:

Before (every BLE attempt):
```
[Govee] [BLE] failed to power on adapter: Timeout waiting for Noble to be powered on.
[Govee] [RGBIC Strip Lights] could not be updated as BLE adapter not in correct state [unauthorized]
[Govee] [RGBIC Strip Lights] BLE update failed: Invalid peripheral ID or Address db:48:c2:06:32:5a.
```

After (toggling from the Home app, no errors):
```
[Govee] [RGBIC Strip Lights] current state [off].
[Govee] [RGBIC Strip Lights] current state [on].
[Govee] [RGBIC Strip Lights] current state [off].
[Govee] [RGBIC Strip Lights] current state [on].
```

The strip physically responds to on/off and colour changes from HomeKit. A 15s scan on the same machine confirms macOS returns empty `address` fields for all peripherals (so connect-by-address can never work) while local names are present.

## Notes

- The `unauthorized` state in the "before" log is macOS TCC: the `node` binary needs to be granted Bluetooth permission manually for a daemon install (documented in the README change).
- Scan timeout is bounded by the existing `CONNECTION_TIMEOUT` (minus 1s, min 4s), so overall behaviour under the outer `Promise.race` is unchanged.
- `btClient.reset()` before connect proved harmless on darwin in testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFvS8cQFCDWD6FNd9f64up
