### PR TITLE
feat: control the H1250's zones with the frame the device accepts, since Govee never delivers its toggle capabilities

### DIFF
--- a/lib/device/light-zones.test.js
+++ b/lib/device/light-zones.test.js
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+
+import { makeAccessory, makePlatform } from '../../test/harness.js'
+import deviceLight from './light.js'
+
+/**
+ * The H1250 ceiling light has a main downlight panel and a background ring that
+ * switch independently. Govee lists `mainLightToggle` and `backgroundLightToggle`
+ * for it and answers `{"status":"success"}` to both, then never delivers the
+ * command - so the tiles reported success to HomeKit and the light did nothing,
+ * with no way for the plugin to tell (#1333).
+ *
+ * These models take the frame the device reports its own zones with instead.
+ * Everything else about the tiles is shared with the models whose toggles do
+ * work, so what matters here is that the right thing goes out, that state comes
+ * back, and that no other light is dragged along with it.
+ */
+
+function build(model, context = {}) {
+  const sent = []
+  const platform = makePlatform({
+    sendDeviceUpdate: async (_accessory, params) => {
+      sent.push(params)
+    },
+  })
+  const accessory = makeAccessory(model, context)
+  const device = new deviceLight(platform, accessory)
+  device.accessory = accessory
+  return { accessory, device, sent }
+}
+
+function tiles(accessory) {
+  return accessory.services
+    .filter(service => service.type === 'Switch')
+    .map(service => service.displayName)
+}
+
+// `aa 30 <main> <background>`, so the main panel is off and the ring is on
+const MAIN_OFF_RING_ON = 'qjAAAQAAAAAAAAAAAAAAAAAAAJs='
+
+describe('a light whose zones govee never delivers', () => {
+  it('offers a tile per zone once aws is available', () => {
+    const { accessory } = build('H1250', { useAwsControl: true })
+
+    expect(tiles(accessory)).toEqual(['Main Light', 'Background Light'])
+  })
+
+  it('offers no tiles without aws, rather than ones that quietly do nothing', () => {
+    // The frame only goes over AWS, which needs account credentials rather than
+    // just an api key. Tiles that accept a tap and drop it are worse than none
+    const { accessory } = build('H1250', { useAwsControl: false, useOpenApiControl: true })
+
+    expect(tiles(accessory)).toEqual([])
+  })
+
+  it('ignores the toggles govee lists for it, even with the api connected', () => {
+    // Govee reports both capabilities for this model. Believing them is exactly
+    // the bug - the tiles would appear and never work
+    const { accessory } = build('H1250', {
+      useAwsControl: false,
+      useOpenApiControl: true,
+      openApiCapabilities: { mainLightToggle: {}, backgroundLightToggle: {} },
+    })
+
+    expect(tiles(accessory)).toEqual([])
+  })
+
+  it('sends the frame the device accepts, not the capability', async () => {
+    const { accessory, sent } = build('H1250', { useAwsControl: true })
+
+    await accessory.getService('Background Light')
+      .getCharacteristic('On')
+      .setHandler(true)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0].cmd).toBe('zoneState')
+    expect(sent[0]).toMatchObject({ zone: 'background', value: true })
+  })
+
+  it('reads both zones back from the frame the device reports', () => {
+    // This arrives unprompted, which is how a change made in the Govee app or at
+    // the wall switch reaches the tiles
+    const { accessory, device } = build('H1250', { useAwsControl: true })
+
+    device.externalUpdate({ commands: [MAIN_OFF_RING_ON] })
+
+    expect(accessory.getService('Main Light').getCharacteristic('On').value).toBe(false)
+    expect(accessory.getService('Background Light').getCharacteristic('On').value).toBe(true)
+  })
+})
+
+describe('every other light', () => {
+  it('is left alone by the zone handling', () => {
+    // The H1252 is an ordinary rgb light sharing this handler. It should gain no
+    // zone tiles and take no notice of a zone frame
+    const { accessory, device } = build('H1252', { useAwsControl: true })
+
+    expect(tiles(accessory)).toEqual([])
+    expect(() => device.externalUpdate({ commands: [MAIN_OFF_RING_ON] })).not.toThrow()
+    expect(tiles(accessory)).toEqual([])
+  })
+
+  it('still takes its zone state from the toggles when they work', () => {
+    // The H1270 advertises the same two capabilities and, as far as anyone has
+    // reported, they are delivered - so it stays on the toggle path
+    const { accessory, device } = build('H1270', {
+      useOpenApiControl: true,
+      openApiCapabilities: { mainLightToggle: {}, backgroundLightToggle: {} },
+    })
+
+    expect(tiles(accessory)).toEqual(['Main Light', 'Background Light'])
+
+    device.externalUpdate({ toggles: { mainLightToggle: true } })
+
+    expect(accessory.getService('Main Light').getCharacteristic('On').value).toBe(true)
+  })
+})

--- a/lib/device/light.js
+++ b/lib/device/light.js
@@ -6,13 +6,42 @@ import {
 } from '../utils/colour.js'
 import platformConsts from '../utils/constants.js'
 import {
+  base64ToHex,
   generateRandomString,
+  getTwoItemPosition,
   hasProperty,
+  hexToTwoItems,
   parseError,
   sleep,
 } from '../utils/functions.js'
 import platformLang from '../utils/lang-en.js'
 import GoveeDevice from './base.js'
+
+/**
+ * The zone state of a light that reports both of its zones in one frame, as
+ * `aa 30 <main> <background>`.
+ *
+ * Reported under the same capability instances the OpenAPI uses, so zone state
+ * reads the same whichever connection carried it. This frame arrives unprompted
+ * whenever the zones change, including from the Govee app or the wall switch,
+ * which is how the tiles stay right rather than only echoing our own writes -
+ * all the toggles could ever manage on these models (#1333).
+ *
+ * @param {string[]} [commands] the base64 frames from the payload
+ * @returns {object} the zones found, keyed by capability instance
+ */
+function readZoneFrame(commands = []) {
+  const zones = {}
+  commands.forEach((command) => {
+    const hexParts = hexToTwoItems(base64ToHex(command))
+    if (`${getTwoItemPosition(hexParts, 1)}${getTwoItemPosition(hexParts, 2)}` !== 'aa30') {
+      return
+    }
+    zones.mainLightToggle = getTwoItemPosition(hexParts, 3) === '01'
+    zones.backgroundLightToggle = getTwoItemPosition(hexParts, 4) === '01'
+  })
+  return zones
+}
 
 export default class extends GoveeDevice {
   constructor(platform, accessory) {
@@ -199,26 +228,40 @@ export default class extends GoveeDevice {
     // Some lights (e.g. the H1270 Ceiling Light Ultra) have two independently
     // controllable zones - a main/bottom panel and a background/top light. Govee
     // exposes these as OpenAPI toggle capabilities, so add a switch for each zone
-    // the device reports. These are only controllable via the OpenAPI connection.
+    // the device reports, controlled over the OpenAPI connection.
+    //
+    // The models in `zoneLightModels` advertise those same capabilities but the
+    // cloud never delivers them, so they are driven by a raw frame over AWS
+    // instead. That is the only difference - the tiles, their state and the way
+    // a failure is undone are the same either way (#1333)
     this.zoneServices = {}
     this.zoneCache = {}
+    this.hasRawZones = platformConsts.zoneLightModels.includes(accessory.context.gvModel)
     const zoneToggleDefs = [
-      { instance: 'mainLightToggle', name: 'Main Light' },
-      { instance: 'backgroundLightToggle', name: 'Background Light' },
+      { instance: 'mainLightToggle', zone: 'main', name: 'Main Light' },
+      { instance: 'backgroundLightToggle', zone: 'background', name: 'Background Light' },
     ]
     const openApiCaps = accessory.context.openApiCapabilities || {}
-    zoneToggleDefs.forEach(({ instance, name }) => {
+    zoneToggleDefs.forEach(({ instance, zone, name }) => {
       const existingService = this.accessory.getService(name)
-      if (accessory.context.useOpenApiControl && openApiCaps[instance]) {
+
+      // The raw frame goes over AWS, which needs Govee account credentials
+      // rather than just an API key
+      const isControllable = this.hasRawZones
+        ? accessory.context.useAwsControl
+        : accessory.context.useOpenApiControl && openApiCaps[instance]
+
+      if (isControllable) {
         const service = existingService
           || this.accessory.addService(this.hapServ.Switch, name, instance)
         service
           .getCharacteristic(this.hapChar.On)
-          .onSet(async value => this.internalZoneUpdate(instance, name, value))
+          .onSet(async value => this.internalZoneUpdate(instance, zone, name, value))
         this.zoneServices[instance] = service
         this.zoneCache[instance] = service.getCharacteristic(this.hapChar.On).value ? 1 : 0
       } else if (existingService) {
-        // Capability no longer available (or OpenAPI disabled) so remove the switch
+        // Capability no longer available (or the connection it needs is off) so
+        // remove the switch
         this.accessory.removeService(existingService)
       }
     })
@@ -274,7 +317,7 @@ export default class extends GoveeDevice {
     }
   }
 
-  async internalZoneUpdate(instance, name, value) {
+  async internalZoneUpdate(instance, zone, name, value) {
     const service = this.zoneServices[instance]
     try {
       const newValue = value ? 1 : 0
@@ -284,15 +327,26 @@ export default class extends GoveeDevice {
         return
       }
 
-      // These toggles are only controllable via the OpenAPI (cloud) connection
-      await this.platform.sendDeviceUpdate(this.accessory, {
-        cmd: 'openApi',
-        openApi: {
-          instance,
-          capabilityType: 'devices.capabilities.toggle',
-          value: newValue,
-        },
-      })
+      if (this.hasRawZones) {
+        // This model's toggles are accepted and ignored, so send the frame the
+        // device itself uses. The command builder leaves lanParams off, so this
+        // one skips LAN - which the device ignores - and goes over AWS
+        await this.platform.sendDeviceUpdate(this.accessory, {
+          cmd: 'zoneState',
+          zone,
+          value: newValue === 1,
+        })
+      } else {
+        // These toggles are only controllable via the OpenAPI (cloud) connection
+        await this.platform.sendDeviceUpdate(this.accessory, {
+          cmd: 'openApi',
+          openApi: {
+            instance,
+            capabilityType: 'devices.capabilities.toggle',
+            value: newValue,
+          },
+        })
+      }
 
       // Cache the new state and log
       this.zoneCache[instance] = newValue
@@ -663,11 +717,13 @@ export default class extends GoveeDevice {
       }
     }
 
-    // Update any independently-controllable light zones (e.g. main/background)
-    if (params.toggles) {
+    // Update any independently-controllable light zones (e.g. main/background),
+    // read from the device's own frame where the toggles report nothing
+    const zoneToggles = this.hasRawZones ? readZoneFrame(params.commands) : params.toggles
+    if (zoneToggles) {
       Object.entries(this.zoneServices).forEach(([instance, service]) => {
-        if (hasProperty(params.toggles, instance)) {
-          const newValue = params.toggles[instance] ? 1 : 0
+        if (hasProperty(zoneToggles, instance)) {
+          const newValue = zoneToggles[instance] ? 1 : 0
           if (this.zoneCache[instance] !== newValue) {
             this.zoneCache[instance] = newValue
             service.updateCharacteristic(this.hapChar.On, newValue === 1)

--- a/lib/utils/command-builder.js
+++ b/lib/utils/command-builder.js
@@ -1,7 +1,7 @@
 import { CMD } from './ble-protocol.js'
 import { k2rgb } from './colour.js'
 import { getDeviceCapabilities } from './device-capabilities.js'
-import { base64ToHex } from './functions.js'
+import { base64ToHex, generateCodeFromHexValues } from './functions.js'
 
 /**
  * Builds connection-specific command params from a high-level device command.
@@ -26,6 +26,8 @@ export function buildCommand(params, context) {
       return buildPtRealCommand(params)
     case 'openApi':
       return buildOpenApiCommand(params)
+    case 'zoneState':
+      return buildZoneStateCommand(params)
     case 'brightness':
       return buildBrightnessCommand(params, context)
     case 'color':
@@ -114,6 +116,32 @@ function buildOpenApiCommand(params) {
   }
   return {
     openApiParams: { cmd: 'openApi', ...params.openApi },
+  }
+}
+
+// A two-zone light reports its zones as `aa 30 <main> <background>` and takes
+// `33 30 <zone> <state>` to set one of them, where zone 00 is the main panel
+// and 01 the background ring (#1333)
+const ZONE_BYTE = { main: 0x00, background: 0x01 }
+
+function buildZoneStateCommand(params) {
+  const zone = ZONE_BYTE[params.zone]
+  if (zone === undefined) {
+    // Falling back to the main panel would switch the wrong light, which is far
+    // harder to notice than an outright failure
+    throw new Error(`Unknown light zone [${params.zone}] for ${params.cmd}`)
+  }
+
+  // Deliberately no lanParams. This model ignores `ptReal` over LAN, and LAN is
+  // fire-and-forget UDP, so sending it there would resolve and count as done -
+  // the command would never be retried over AWS. Leaving lanParams off lets the
+  // existing guard skip LAN for this one command, and every other command on
+  // the device carries on taking the faster local path.
+  return {
+    awsParams: {
+      cmd: 'ptReal',
+      data: { command: [generateCodeFromHexValues([0x33, 0x30, zone, params.value ? 0x01 : 0x00])] },
+    },
   }
 }
 

--- a/lib/utils/command-builder.test.js
+++ b/lib/utils/command-builder.test.js
@@ -292,3 +292,56 @@ describe('every light model builds a sendable command on every connection', () =
     expect(failures).toEqual([])
   })
 })
+
+/**
+ * The H1250 ceiling light has two independently controllable zones - a main
+ * downlight panel and a background ring. Govee lists `mainLightToggle` and
+ * `backgroundLightToggle` for it and answers `{"status":"success"}` to both,
+ * but the command never reaches the device (#1333).
+ *
+ * What the device does accept is the frame it reports its own zones with:
+ *
+ *   33 30 <zone> <state>    zone 00 = main, 01 = background
+ *                           state 00 = off, 01 = on
+ *
+ * The four frames below were confirmed against the hardware, so they are
+ * pinned exactly rather than rebuilt from the same helper that produces them.
+ */
+describe('what goes out for a light zone', () => {
+  const frameFor = params => buildCommand(params).awsParams.data.command[0]
+
+  it('turns the main panel on', () => {
+    expect(frameFor({ cmd: 'zoneState', zone: 'main', value: true }))
+      .toBe('MzAAAQAAAAAAAAAAAAAAAAAAAAI=')
+  })
+
+  it('turns the main panel off', () => {
+    expect(frameFor({ cmd: 'zoneState', zone: 'main', value: false }))
+      .toBe('MzAAAAAAAAAAAAAAAAAAAAAAAAM=')
+  })
+
+  it('turns the background ring on', () => {
+    expect(frameFor({ cmd: 'zoneState', zone: 'background', value: true }))
+      .toBe('MzABAQAAAAAAAAAAAAAAAAAAAAM=')
+  })
+
+  it('turns the background ring off', () => {
+    expect(frameFor({ cmd: 'zoneState', zone: 'background', value: false }))
+      .toBe('MzABAAAAAAAAAAAAAAAAAAAAAAI=')
+  })
+
+  it('goes over aws only, since this model ignores the frame over lan', () => {
+    // LAN is fire-and-forget, so offering it there would count as sent and the
+    // command would never reach the device
+    const built = buildCommand({ cmd: 'zoneState', zone: 'main', value: true })
+    expect(built.awsParams.cmd).toBe('ptReal')
+    expect(built.lanParams).toBeUndefined()
+  })
+
+  it('refuses a zone it does not know', () => {
+    // Quietly treating this as the main panel would switch the wrong light,
+    // which is far harder to spot than an outright failure
+    expect(() => buildCommand({ cmd: 'zoneState', zone: 'ceiling', value: true }))
+      .toThrow(/zone/i)
+  })
+})

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -714,6 +714,20 @@ export default {
     ],
   },
 
+  // Two-zone lights whose zones Govee lists but never routes. Not a device type
+  // of its own - these stay in `models.rgb` like any other light, and only the
+  // way their zones are driven differs.
+  //
+  // Govee advertises `mainLightToggle` and `backgroundLightToggle` for these,
+  // and its cloud answers `{"status":"success"}` to both, but the command never
+  // reaches the device. Nothing reports a failure, so the plugin cannot tell -
+  // the tiles simply do nothing. The models here take the raw frame the device
+  // itself reports its zones with instead (#1333).
+  //
+  // The H1270 is deliberately absent. It advertises the same capabilities, but
+  // nobody has confirmed it shares the fault, so it stays on the toggle path.
+  zoneLightModels: ['H1250'],
+
   matterModels: [
     'H1401',
     'H14C0',


### PR DESCRIPTION
## :recycle: Current situation

The H1250 (Ceiling Light Pro) has two independently switchable zones, the same as the H1270 that #1306 added support for: a main downlight panel and a background ring.

Govee lists both capabilities for it, so the zone tiles from #1306 are created exactly as designed:

```
[Govee] [Kitchen Ceiling Light] openapi category [devices.types.light] capabilities [powerSwitch (devices.capabilities.on_off), brightness (devices.capabilities.range), segmentedBrightness (devices.capabilities.segment_color_setting), segmentedColorRgb (devices.capabilities.segment_color_setting), colorRgb (devices.capabilities.color_setting), colorTemperatureK (devices.capabilities.color_setting), gradientToggle (devices.capabilities.toggle), lightScene (devices.capabilities.dynamic_scene), diyScene (devices.capabilities.dynamic_scene), snapshot (devices.capabilities.dynamic_scene), mainLightToggle (devices.capabilities.toggle), backgroundLightToggle (devices.capabilities.toggle)].
```

The tiles just never do anything. Sending either toggle returns HTTP 200 with `capability.state.status === "success"`, and the light does not change. I tried each one six times, going straight at the API rather than through the plugin. `powerSwitch` and `brightness` worked visibly immediately before and after every attempt, so the connection was live throughout.

Two things make this worse than a plain "unsupported model":

- **The plugin cannot detect it.** `describeControlFailure` only treats an explicit `failure` status as an error, so an accepted-and-dropped command reports success straight back to HomeKit. The tile moves, the light does not.
- **The state cannot be read back either.** `/device/state` returns `""` for both toggles, so there is nothing to correct the tile with afterwards.

`gradientToggle` behaves the same way, which suggests it is the whole `devices.capabilities.toggle` class that is not routed on this SKU rather than the two zone names specifically. So I do not think this is a mapping or ordering problem — there is no ordering that would help when neither instance is delivered.

## :bulb: Proposed solution

The device does accept the frame it reports its own zones with, so these models use that instead of the capability:

```
33 30 <zone> <state>        sets one zone, 00 = main, 01 = background
aa 30 <main> <background>   how the device reports both back
```

This goes through the existing zone path rather than beside it. `zoneToggleDefs` gains a `zone` alongside the capability instance it already had, and `internalZoneUpdate` picks the transport. Everything else — the tiles, the cache, the way a failed command is undone — is shared, and unchanged.

A new `platformConsts.zoneLightModels` names the models that need it. It is not a device type: these stay in `models.rgb` and are dispatched to `deviceLight` like any other light, and only the way their zones are driven differs. The H1270 is deliberately not in that list. It advertises the same two capabilities, but nobody has reported that they fail on it, so it stays exactly where it is.

Reading state back is the part that was not possible before. The `aa 30` frame arrives unprompted whenever the zones change, including from the Govee app or the wall switch, so the tiles now follow the light instead of only echoing writes the plugin made itself. It is reported under the same capability instance names the OpenAPI uses, which is what lets `externalUpdate` stay as it was.

One deliberate omission: `buildZoneStateCommand` returns no `lanParams`. This model ignores `ptReal` over LAN, and since LAN is fire-and-forget the send would resolve and count as delivered, so the command would never reach AWS. Leaving `lanParams` off lets the existing guard skip LAN for this one command while everything else on the device keeps using the faster local path.

## :gear: Release Notes

H1250 (Ceiling Light Pro) owners get working **Main Light** and **Background Light** tiles. They also now track changes made outside HomeKit, so switching a zone in the Govee app or at the wall switch updates the tile.

These tiles need Govee account credentials configured, not just an API key, because the frame goes over AWS. Without them no zone tiles are offered at all, rather than tiles that accept a tap and quietly do nothing.

Nothing changes for any other model, including the H1270.

## :heavy_plus_sign: Additional Information

Tested on real hardware (H1250, firmware 1.01.31, hardware 1.04.03). Each tap sent the expected frame and the device reported the matching state back:

| tapped | sent | device reported | main / background |
|---|---|---|---|
| Background off | `33 30 01 00` | `aa 30 01 00` | on / off |
| Background on | `33 30 01 01` | `aa 30 01 01` | on / on |
| Main off | `33 30 00 00` | `aa 30 00 01` | off / on |
| Main on | `33 30 00 01` | `aa 30 01 01` | on / on |

Both zones switched the light itself each time, and the tiles matched afterwards.

One thing worth flagging separately: the device's confirmation of a `ptReal` command sometimes comes back with an empty `op`, carrying only `state.result`. Nothing parses out of that, so it reaches the unrecognised-payload report, and because each one carries its own transaction id the fingerprint never repeats and it is logged every time. That is not new here — scenes have been sent as `ptReal` over AWS for a long time — so I have left it out of this PR and will raise it on its own.

### Testing

13 tests added, and `npm test` passes.

`lib/utils/command-builder.test.js` pins all four zone frames against the values confirmed on the hardware, rather than rebuilding them from the same helper that produces them, plus the AWS-only routing and an unknown zone throwing rather than falling back to the main panel.

`lib/device/light-zones.test.js` covers the tiles: that both appear once AWS is available, that none are offered without it, that the listed-but-dead capabilities are ignored even with the API connected, that a tap sends the frame rather than the capability, and that an `aa 30` frame updates both tiles.

It also covers the models that should not be affected — an ordinary H1252 gains no zone tiles and ignores a zone frame entirely, and the H1270 still takes its zone state from the toggles.

`test/model-snapshot.txt` is unchanged, which is the check that no other model's services moved.

### Reviewer Nudging

`lib/device/light.js` is the place to start, at `zoneToggleDefs` — the diff there is mostly the availability check and passing `zone` through. Then `buildZoneStateCommand` in `lib/utils/command-builder.js` for the frame itself, and `readZoneFrame` at the top of `light.js` for the read path.

The thing most worth a second opinion is the decision to keep `zoneLightModels` an explicit list rather than trying to detect the fault at runtime. Since the failure is a success response, there is nothing to detect, and guessing wrong in either direction is silent — so I would rather name the one model I can actually test.
