### PR TITLE
fix(H5106): accept 20-byte AWS status frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `@homebridge-plugins/homebridge-govee` will be documented
 
 ### Changed
 
+- fix: read 20-byte H5106 status frames instead of leaving temperature and humidity stale (#1322)
 - feat: control the H1250 zones with the device's own frame, as govee ignores its toggles (#1343) (@Principe1218)
 - fix: explain in the log when zone tiles are missing because aws credentials are not set
 - fix: restore debug logging when the plugin runs in a child bridge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ All notable changes to `@homebridge-plugins/homebridge-govee` will be documented
 
 ### Changed
 
-- fix: read 20-byte H5106 status frames instead of leaving temperature and humidity stale (#1322)
 - feat: control the H1250 zones with the device's own frame, as govee ignores its toggles (#1343) (@Principe1218)
 - fix: explain in the log when zone tiles are missing because aws credentials are not set
 - fix: restore debug logging when the plugin runs in a child bridge
 - fix: turn adaptive lighting off when a colour is chosen outside HomeKit
 - fix: send a colour change when only the saturation moves, on every night light
 - fix: listen for saturation on the main light too, not only hue
+- fix: accept 20-byte H5106 status frames (@danieloleary)
 
 ## v11.34.1 (2026-08-06)
 

--- a/lib/device/sensor-monitor.js
+++ b/lib/device/sensor-monitor.js
@@ -108,7 +108,7 @@ export default class extends GoveeDevice {
         case 'aa0e':
           break
         default: {
-          if (hexParts.length < 21) {
+          if (hexParts.length < 20) {
             break
           }
           const tempInCen = Math.round((hexToDecimal(`0x${deviceFunction}`) + (this.accessory.context.offTemp / 100)) / 10) / 10

--- a/lib/device/sensor-monitor.test.js
+++ b/lib/device/sensor-monitor.test.js
@@ -1,0 +1,92 @@
+import { Buffer } from 'node:buffer'
+
+import { describe, expect, it } from 'vitest'
+
+import { makeAccessory, makePlatform } from '../../test/harness.js'
+import deviceSensorMonitor from './sensor-monitor.js'
+
+function build(context = {}) {
+  const accessory = makeAccessory('H5106', {
+    offTemp: 0,
+    offHumi: 0,
+    ...context,
+  })
+  const device = new deviceSensorMonitor(makePlatform(), accessory)
+  return device
+}
+
+function readings(device) {
+  return {
+    temperature: device.tempService.getCharacteristic('CurrentTemperature').value,
+    humidity: device.humiService.getCharacteristic('CurrentRelativeHumidity').value,
+  }
+}
+
+// Synthetic H5106 status frame: bytes 1-2 are temperature in hundredths,
+// bytes 10-11 are humidity in hundredths, and bytes 19-20 are PM2.5.
+const COMPACT_STATUS_HEX = '092e0000000000000015b800000000000000000c'
+const commandFromHex = hex => Buffer.from(hex, 'hex').toString('base64')
+
+describe('the monitor sensor readings', () => {
+  it('normalises raw hundredths into HomeKit temperature and humidity', async () => {
+    const device = build()
+
+    await device.externalUpdate({ temperature: 2150, humidity: 5560 })
+
+    expect(readings(device)).toEqual({ temperature: 21.5, humidity: 55.6 })
+  })
+
+  it('applies configured temperature and humidity offsets before normalising', async () => {
+    const device = build({ offTemp: 150, offHumi: -250 })
+
+    await device.externalUpdate({ temperature: 2150, humidity: 5560 })
+
+    expect(readings(device)).toEqual({ temperature: 23, humidity: 53.1 })
+  })
+
+  it('keeps humidity within HomeKit’s zero to one-hundred range', async () => {
+    const device = build()
+
+    await device.externalUpdate({ humidity: 10001 })
+    expect(readings(device).humidity).toBe(100)
+
+    await device.externalUpdate({ humidity: -1 })
+    expect(readings(device).humidity).toBe(0)
+  })
+
+  it('keeps valid readings when a later update is missing or malformed', async () => {
+    const device = build()
+    await device.externalUpdate({ temperature: 2150, humidity: 5560 })
+
+    await device.externalUpdate({})
+    await device.externalUpdate({ temperature: 'not-a-number', humidity: 'not-a-number' })
+
+    expect(readings(device)).toEqual({ temperature: 21.5, humidity: 55.6 })
+  })
+
+  it('decodes compact twenty-byte monitor status frames', async () => {
+    const device = build()
+
+    await device.externalUpdate({ commands: [commandFromHex(COMPACT_STATUS_HEX)] })
+
+    expect(readings(device)).toEqual({ temperature: 23.5, humidity: 56 })
+    expect(device.airService.getCharacteristic('PM2_5Density').value).toBe(12)
+  })
+
+  it('ignores monitor status frames shorter than twenty bytes', async () => {
+    const device = build()
+
+    await device.externalUpdate({ commands: [commandFromHex(COMPACT_STATUS_HEX.slice(0, -2))] })
+
+    expect(readings(device)).toEqual({ temperature: 0, humidity: 0 })
+  })
+
+  it('keeps decoding legacy monitor status frames with a trailing byte', async () => {
+    const device = build()
+
+    await device.externalUpdate({ commands: [commandFromHex(`${COMPACT_STATUS_HEX}00`)] })
+
+    expect(readings(device)).toEqual({ temperature: 23.5, humidity: 56 })
+    expect(device.airService.getCharacteristic('PM2_5Density').value).toBe(12)
+  })
+})


### PR DESCRIPTION
## Summary

H5106 AWS status responses can use a 20-byte first command frame. The current handler requires at least 21 bytes, so it ignores those readings and leaves temperature, humidity, and PM2.5 stale.

This changes the minimum frame length from 21 to 20. The existing field layout, scaling, and longer-frame behavior are unchanged.

## Local evidence

- A fresh HTTP device-list response for the H5106 contained `online` only, with no temperature or humidity fields.
- A fresh AWS status request returned a 20-byte frame.
- Before the change, the installed v11.34.1 handler ignored the same fresh frame and left the reading stale.
- With this exact one-line change installed, the restarted Govee child bridge reported fresh `26.1 C / 50%` readings and continued receiving updates without post-restart errors.
- An independent Bluetooth broadcast during validation agreed on temperature and was within 0.3 percentage points on humidity.

The live frames and device identifiers remain local. The repository test uses synthetic data.

## Test plan

- [x] Frames shorter than 20 bytes remain ignored
- [x] A 20-byte frame is decoded
- [x] A 21-byte frame still follows the existing decode path
- [x] Regression mutation: restoring the old 21-byte guard fails only the new 20-byte test
- [x] Full suite: 416 passed on Node 22, Node 24, and Node 26
- [x] ESLint and `git diff --check` passed
- [x] Repository changelog sync is clean and idempotent
- [ ] Upstream CI passes after first-time-contributor approval

Fixes #1322