### PR TITLE
feat: give the H1250's zones independent color and brightness

### DIFF
--- a/lib/device/light-zones.test.js
+++ b/lib/device/light-zones.test.js
@@ -487,6 +487,19 @@ describe('setting one zone\'s color temperature', () => {
 
     expect(sent).toHaveLength(1)
   })
+
+  it('does not resend when adaptive lighting nudges mired without moving the rounded kelvin', async () => {
+    // Adaptive lighting drifts mired continuously, but Govee only takes kelvin
+    // to the nearest 100 - comparing raw mired sent a real command on almost
+    // every adaptive lighting tick, even though nothing the device can act on
+    // had actually changed (370M and 368M both round to 2700K)
+    const { device, sent } = build('H1250', { useAwsControl: true })
+
+    await device.internalZoneCTUpdate('mainLightToggle', 'main', 'Main Light', 370)
+    await device.internalZoneCTUpdate('mainLightToggle', 'main', 'Main Light', 368)
+
+    expect(sent).toHaveLength(1)
+  })
 })
 
 // The light's own report: `aa a5 <page>` then four groups of <level> <r> <g> <b>.

--- a/lib/device/light-zones.test.js
+++ b/lib/device/light-zones.test.js
@@ -420,3 +420,37 @@ describe('dimming one zone', () => {
     expect(device.zoneServices.mainLightToggle.getCharacteristic('Brightness').value).toBe(25)
   })
 })
+
+describe('colouring one zone', () => {
+  it('converts hue and the tile\'s own saturation into rgb', async () => {
+    const { device, sent } = build('H1250', { useAwsControl: true })
+    device.zoneServices.mainLightToggle.updateCharacteristic('Saturation', 100)
+
+    await device.internalZoneColourUpdate('mainLightToggle', 'main', 'Main Light', 0)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0].cmd).toBe('zoneColour')
+    expect(sent[0].lightSegments).toEqual([16])
+    expect(sent[0].value).toEqual({ r: 255, g: 0, b: 0 })
+  })
+
+  it('reads the saturation of the zone being set, not another tile\'s', async () => {
+    const { device, sent } = build('H1250', { useAwsControl: true })
+    device.zoneServices.backgroundLightToggle.updateCharacteristic('Saturation', 100)
+    device.zoneServices.mainLightToggle.updateCharacteristic('Saturation', 0)
+
+    await device.internalZoneColourUpdate('backgroundLightToggle', 'background', 'Background Light', 120)
+
+    expect(sent[0].value).toEqual({ r: 0, g: 255, b: 0 })
+  })
+
+  it('does not resend a colour the zone already has', async () => {
+    const { device, sent } = build('H1250', { useAwsControl: true })
+    device.zoneServices.mainLightToggle.updateCharacteristic('Saturation', 100)
+
+    await device.internalZoneColourUpdate('mainLightToggle', 'main', 'Main Light', 0)
+    await device.internalZoneColourUpdate('mainLightToggle', 'main', 'Main Light', 0)
+
+    expect(sent).toHaveLength(1)
+  })
+})

--- a/lib/device/light-zones.test.js
+++ b/lib/device/light-zones.test.js
@@ -372,3 +372,51 @@ describe('a zone tile', () => {
     })
   })
 })
+
+describe('dimming one zone', () => {
+  it('sends that zone\'s light segments and nothing else', async () => {
+    const { device, sent } = build('H1250', { useAwsControl: true })
+
+    await device.internalZoneBrightnessUpdate('mainLightToggle', 'main', 'Main Light', 40)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0].cmd).toBe('zoneBrightness')
+    expect(sent[0].lightSegments).toEqual([16])
+    expect(sent[0].value).toBe(40)
+  })
+
+  it('leaves the other zone alone', async () => {
+    const { device, sent } = build('H1250', { useAwsControl: true })
+
+    await device.internalZoneBrightnessUpdate('backgroundLightToggle', 'background', 'Background Light', 40)
+
+    expect(sent[0].lightSegments).toHaveLength(16)
+    expect(sent[0].lightSegments).not.toContain(16)
+  })
+
+  it('does not resend a value the zone already has', async () => {
+    const { device, sent } = build('H1250', { useAwsControl: true })
+
+    await device.internalZoneBrightnessUpdate('mainLightToggle', 'main', 'Main Light', 40)
+    await device.internalZoneBrightnessUpdate('mainLightToggle', 'main', 'Main Light', 40)
+
+    expect(sent).toHaveLength(1)
+  })
+
+  it('puts the tile back where it was when the command fails', async () => {
+    const { device } = build('H1250', { useAwsControl: true })
+    device.zoneBrightCache.mainLightToggle = 25
+    device.platform.sendDeviceUpdate = async () => {
+      throw new Error('no response')
+    }
+
+    await expect(device.internalZoneBrightnessUpdate('mainLightToggle', 'main', 'Main Light', 80))
+      .rejects
+      .toThrow()
+    await new Promise((resolve) => {
+      setTimeout(resolve, 2100)
+    })
+
+    expect(device.zoneServices.mainLightToggle.getCharacteristic('Brightness').value).toBe(25)
+  })
+})

--- a/lib/device/light-zones.test.js
+++ b/lib/device/light-zones.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { makeAccessory, makePlatform } from '../../test/harness.js'
+import { k2rgb } from '../utils/colour.js'
 import deviceLight from './light.js'
 
 /**
@@ -450,6 +451,37 @@ describe('colouring one zone', () => {
 
     await device.internalZoneColourUpdate('mainLightToggle', 'main', 'Main Light', 0)
     await device.internalZoneColourUpdate('mainLightToggle', 'main', 'Main Light', 0)
+
+    expect(sent).toHaveLength(1)
+  })
+})
+
+describe('setting one zone\'s color temperature', () => {
+  it('converts mireds to the rgb the zone frame takes', async () => {
+    // The zone command carries rgb and nothing else, so a temperature has to be
+    // converted on the way out - the same thing the bluetooth path does
+    const { device, sent } = build('H1250', { useAwsControl: true })
+
+    await device.internalZoneCTUpdate('mainLightToggle', 'main', 'Main Light', 370)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0].cmd).toBe('zoneColour')
+    expect(sent[0].lightSegments).toEqual([16])
+    expect(sent[0].value.r).toBeGreaterThan(sent[0].value.b)
+  })
+
+  it('sends a cool temperature bluer than a warm one', () => {
+    const warm = k2rgb(2700)
+    const cool = k2rgb(6500)
+
+    expect(cool[2]).toBeGreaterThan(warm[2])
+  })
+
+  it('does not resend a temperature the zone already has', async () => {
+    const { device, sent } = build('H1250', { useAwsControl: true })
+
+    await device.internalZoneCTUpdate('mainLightToggle', 'main', 'Main Light', 370)
+    await device.internalZoneCTUpdate('mainLightToggle', 'main', 'Main Light', 370)
 
     expect(sent).toHaveLength(1)
   })

--- a/lib/device/light-zones.test.js
+++ b/lib/device/light-zones.test.js
@@ -31,7 +31,7 @@ function build(model, context = {}) {
 
 function tiles(accessory) {
   return accessory.services
-    .filter(service => service.type === 'Switch')
+    .filter(service => service.type === 'Lightbulb' && service.subtype)
     .map(service => service.displayName)
 }
 
@@ -130,22 +130,245 @@ describe('every other light', () => {
   })
 })
 
-describe('a two-zone light\'s segment layout', () => {
-  it('knows which segments belong to which zone', () => {
+describe('a two-zone light\'s light segment layout', () => {
+  it('knows which light segments belong to which zone', () => {
     const { device } = build('H1250', { useAwsControl: true })
 
-    expect(device.zoneSegments.main).toEqual([16])
+    expect(device.zoneLightSegments.main).toEqual([16])
     // Written as a literal rather than re-deriving the range: a duplicated or
-    // reordered interior segment, or segment 16 leaking into this list, would
-    // still pass a length-and-endpoints check but is exactly the kind of bug
-    // this layout exists to prevent - segment 16 belonging to both zones would
-    // mean setting the background silently repaints the main panel too
-    expect(device.zoneSegments.background).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+    // reordered interior light segment, or light segment 16 leaking into this
+    // list, would still pass a length-and-endpoints check but is exactly the
+    // kind of bug this layout exists to prevent - light segment 16 belonging
+    // to both zones would mean setting the background silently repaints the
+    // main panel too
+    expect(device.zoneLightSegments.background).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
   })
 
   it('leaves a model with no layout alone', () => {
     const { device } = build('H6102', { useAwsControl: true })
 
     expect(device.hasRawZones).toBe(false)
+  })
+})
+
+describe('a zone tile', () => {
+  it('is a lightbulb, so it can carry brightness and color', () => {
+    const { accessory } = build('H1250', { useAwsControl: true })
+    const tile = accessory.getService('Main Light')
+
+    expect(tile.type).toBe('Lightbulb')
+    expect(tile.testCharacteristic('On')).toBe(true)
+    expect(tile.testCharacteristic('Brightness')).toBe(true)
+    expect(tile.testCharacteristic('Hue')).toBe(true)
+    expect(tile.testCharacteristic('Saturation')).toBe(true)
+  })
+
+  it('is the only service with that name, so no switch is left behind', () => {
+    // HomeKit cannot change a service's type in place, and a Switch cannot
+    // carry brightness. Leaving the old one would strand the tile on On-only
+    const { accessory, device } = build('H1250', { useAwsControl: true })
+
+    expect(accessory.services.filter(service => service.displayName === 'Main Light')).toHaveLength(1)
+    expect(device.zoneServices.mainLightToggle.type).toBe('Lightbulb')
+  })
+
+  it('replaces a pre-existing switch with a lightbulb of the same name', () => {
+    // The exact scenario the conversion has to handle: an owner who already
+    // set up both tiles under the already-shipped on/off feature. A stale
+    // Switch left in place would leave that owner stuck on On-only forever.
+    //
+    // Both zones are seeded here, not just one: the base Lightbulb service's
+    // own unrelated switch-to-lightbulb migration (elsewhere in this
+    // constructor, for the main light) removes the FIRST Switch service it
+    // finds by type, regardless of name - so a test seeding only one zone's
+    // switch can pass even if this zone-specific migration is broken, because
+    // the other cleanup silently covers for it. Two zones means at least one
+    // has to survive on its own
+    const platform = makePlatform({ sendDeviceUpdate: async () => {} })
+    const accessory = makeAccessory('H1250', { useAwsControl: true })
+    accessory.addService('Switch', 'Main Light', 'mainLightToggle')
+    accessory.addService('Switch', 'Background Light', 'backgroundLightToggle')
+
+    const device = new deviceLight(platform, accessory)
+    device.accessory = accessory
+
+    ;['Main Light', 'Background Light'].forEach((name) => {
+      const matches = accessory.services.filter(service => service.displayName === name)
+      expect(matches).toHaveLength(1)
+      expect(matches[0].type).toBe('Lightbulb')
+      expect(matches[0].testCharacteristic('Brightness')).toBe(true)
+    })
+  })
+
+  it('does not tear down an already-migrated lightbulb on a later restart', () => {
+    // A real HAP Service has no `.type` field - only the fake harness invents
+    // one (as `hapType`, matched by `getService`/`getServiceById`) for tests
+    // elsewhere to read as a stand-in. Code that leaned on `.type` to
+    // recognize an already-migrated lightbulb would see `undefined` on real
+    // hardware and read every restart as "still a stale Switch", tearing the
+    // tile down and rebuilding it every single boot even though nothing had
+    // changed.
+    //
+    // Deleting `.type` below - while leaving `hapType` alone - reproduces
+    // exactly that gap: it removes the field a regression would read while
+    // keeping the field production lookups actually use, so a reintroduced
+    // `.type` comparison genuinely fails this test rather than silently
+    // passing against the harness's own convenience field
+    const { accessory } = build('H1250', { useAwsControl: true })
+    const lightbulbFromFirstBoot = accessory.getService('Main Light')
+    accessory.services.forEach((service) => {
+      delete service.type
+    })
+
+    const platform = makePlatform({ sendDeviceUpdate: async () => {} })
+    const device = new deviceLight(platform, accessory)
+    device.accessory = accessory
+
+    expect(accessory.getService('Main Light')).toBe(lightbulbFromFirstBoot)
+  })
+
+  it('gives a toggle-driven zone on/off only, with no sliders that would do nothing', () => {
+    const { accessory } = build('H1270', {
+      useOpenApiControl: true,
+      openApiCapabilities: { mainLightToggle: true, backgroundLightToggle: true },
+    })
+    const tile = accessory.getService('Main Light')
+
+    expect(tile.testCharacteristic('On')).toBe(true)
+    expect(tile.testCharacteristic('Brightness')).toBe(false)
+  })
+
+  it('carries color temperature, which adaptive lighting requires', () => {
+    // HAP is explicit: a service must have BOTH Brightness and
+    // ColorTemperature before an AdaptiveLightingController can attach to it
+    const { accessory } = build('H1250', { useAwsControl: true })
+    const tile = accessory.getService('Main Light')
+
+    expect(tile.testCharacteristic('ColorTemperature')).toBe(true)
+  })
+
+  it('gets its own adaptive lighting controller, one per zone', () => {
+    // A controller's id is derived from its service
+    // ("characteristic-transition-<serviceId>"), so each zone's sits alongside
+    // the main light's rather than clashing. Two with the same id would throw
+    const { accessory, device } = build('H1250', { useAwsControl: true })
+
+    expect(Object.keys(device.zoneAlControllers)).toEqual(['mainLightToggle', 'backgroundLightToggle'])
+    expect(accessory.controllers).toHaveLength(3)
+    // A controller pointed at the wrong service would still pass a bare
+    // length check above - this confirms all three are attached to distinct
+    // services rather than, say, two of them both landing on the same tile
+    expect(new Set(accessory.controllers.map(controller => controller.service)).size).toBe(3)
+  })
+
+  it('leaves adaptive lighting off the zones when color handling is turned off', () => {
+    const platform = makePlatform({ sendDeviceUpdate: async () => {} })
+    platform.config.colourSafeMode = true
+    const accessory = makeAccessory('H1250', { useAwsControl: true })
+    const device = new deviceLight(platform, accessory)
+
+    expect(Object.keys(device.zoneAlControllers)).toHaveLength(0)
+    expect(accessory.getService('Main Light').testCharacteristic('ColorTemperature')).toBe(false)
+  })
+
+  it('removes a zone tile when its capability is later withdrawn', () => {
+    // The exact branch whose `existingService` scoping changed during the
+    // getServiceById fix (the "capability gone, remove the tile" else branch)
+    // - simulate the capability disappearing on a restart, the same shape as
+    // the restart tests above, and confirm the stale tile does not survive it
+    const platform1 = makePlatform({ sendDeviceUpdate: async () => {} })
+    const accessory = makeAccessory('H1250', { useAwsControl: true })
+    const device1 = new deviceLight(platform1, accessory)
+    device1.accessory = accessory
+    expect(accessory.getService('Main Light')).toBeDefined()
+
+    accessory.context.useAwsControl = false
+    const platform2 = makePlatform({ sendDeviceUpdate: async () => {} })
+    const device2 = new deviceLight(platform2, accessory)
+    device2.accessory = accessory
+
+    expect(accessory.getService('Main Light')).toBeUndefined()
+  })
+
+  it('removes color temperature from a zone that already carries it when color handling turns off', () => {
+    // No test before this seeded a zone service that already has
+    // ColorTemperature before checking the removal branch - every other test
+    // of that removal starts from a fresh service that never had it to begin
+    // with, which the removal code path would pass trivially either way
+    const platform1 = makePlatform({ sendDeviceUpdate: async () => {} })
+    const accessory = makeAccessory('H1250', { useAwsControl: true })
+    const device1 = new deviceLight(platform1, accessory)
+    device1.accessory = accessory
+    expect(accessory.getService('Main Light').testCharacteristic('ColorTemperature')).toBe(true)
+
+    const platform2 = makePlatform({ sendDeviceUpdate: async () => {} })
+    platform2.config.colourSafeMode = true
+    const device2 = new deviceLight(platform2, accessory)
+    device2.accessory = accessory
+
+    expect(accessory.getService('Main Light').testCharacteristic('ColorTemperature')).toBe(false)
+  })
+
+  it('keeps manual color temperature but skips the controller when adaptive lighting is disabled by shift', () => {
+    // Distinct from colourSafeMode: adaptiveLightingShift: -1 opts out of the
+    // automatic adaptive lighting daemon specifically, not color handling
+    // altogether. This mirrors the main light, a few lines up in this same
+    // file - its ColorTemperature block is gated on colourSafeMode alone,
+    // while its controller block right after is gated on colourSafeMode AND
+    // alShift together, so alShift: -1 alone still leaves it a manual CT
+    // slider with no controller behind it. The zone code was written to
+    // follow that same split, so this checks it does
+    const platform = makePlatform({ sendDeviceUpdate: async () => {} })
+    platform.deviceConf['AA:BB'] = { adaptiveLightingShift: -1 }
+    const accessory = makeAccessory('H1250', { useAwsControl: true })
+    const device = new deviceLight(platform, accessory)
+    device.accessory = accessory
+
+    expect(accessory.getService('Main Light').testCharacteristic('ColorTemperature')).toBe(true)
+    expect(Object.keys(device.zoneAlControllers)).toHaveLength(0)
+    // alShift is shared with the main light too, so its own controller is
+    // skipped for the same reason - nothing here should have configured one
+    expect(accessory.controllers).toHaveLength(0)
+  })
+
+  it('applies the configured brightness step to a zone brightness characteristic', () => {
+    // The main light already throttles command volume this way - an owner who
+    // set brightnessStep did so on purpose, and the zone path rides a raw AWS
+    // frame, which is exactly where unthrottled taps matter most
+    const platform = makePlatform({ sendDeviceUpdate: async () => {} })
+    platform.deviceConf['AA:BB'] = { brightnessStep: 5 }
+    const accessory = makeAccessory('H1250', { useAwsControl: true })
+    const device = new deviceLight(platform, accessory)
+    device.accessory = accessory
+
+    expect(accessory.getService('Main Light').getCharacteristic('Brightness').props.minStep).toBe(5)
+  })
+
+  it('clears stale adaptive lighting characteristics from a zone when color handling turns off', () => {
+    // Real HAP's AdaptiveLightingController is what actually adds these three
+    // characteristics to a service, not this file - simulate that here the way
+    // an earlier boot with adaptive lighting on would have left them behind,
+    // then confirm turning color handling off clears them rather than leaving
+    // a zone that still advertises adaptive lighting with no controller behind it
+    const platform1 = makePlatform({ sendDeviceUpdate: async () => {} })
+    const accessory = makeAccessory('H1250', { useAwsControl: true })
+    const device1 = new deviceLight(platform1, accessory)
+    device1.accessory = accessory
+    const tile = accessory.getService('Main Light')
+    const alCharNames = [
+      'SupportedCharacteristicValueTransitionConfiguration',
+      'CharacteristicValueTransitionControl',
+      'CharacteristicValueActiveTransitionCount',
+    ]
+    alCharNames.forEach(charName => tile.getCharacteristic(charName))
+
+    const platform2 = makePlatform({ sendDeviceUpdate: async () => {} })
+    platform2.config.colourSafeMode = true
+    const device2 = new deviceLight(platform2, accessory)
+    device2.accessory = accessory
+
+    alCharNames.forEach((charName) => {
+      expect(tile.testCharacteristic(charName)).toBe(false)
+    })
   })
 })

--- a/lib/device/light-zones.test.js
+++ b/lib/device/light-zones.test.js
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { Buffer } from 'node:buffer'
+
+import { describe, expect, it, vi } from 'vitest'
 
 import { makeAccessory, makePlatform } from '../../test/harness.js'
 import { k2rgb } from '../utils/colour.js'
@@ -484,5 +486,82 @@ describe('setting one zone\'s color temperature', () => {
     await device.internalZoneCTUpdate('mainLightToggle', 'main', 'Main Light', 370)
 
     expect(sent).toHaveLength(1)
+  })
+})
+
+// The light's own report: `aa a5 <page>` then four groups of <level> <r> <g> <b>.
+// Page 1 covers segments 0-3, page 5 covers segment 16 onward. These are the
+// ring at level 26 in blue, and the main panel at level 70 in green
+const RING_PAGES = [
+  'qqUBGgAA/xoAAP8aAAD/GgAA/w4=',
+  'qqUCGgAA/xoAAP8aAAD/GgAA/w0=',
+  'qqUDGgAA/xoAAP8aAAD/GgAA/ww=',
+  'qqUEGgAA/xoAAP8aAAD/GgAA/ws=',
+]
+const MAIN_PAGE = 'qqUFRgD/AAAAAAAAAAAAAAAAALM='
+
+describe('a zone changed outside homekit', () => {
+  it('reaches the tiles, so the govee app and the wall switch are not invisible', () => {
+    const { accessory, device } = build('H1250', { useAwsControl: true })
+    device.initialised = true
+
+    device.externalUpdate({ commands: [...RING_PAGES, MAIN_PAGE], source: 'AWS' })
+
+    expect(accessory.getService('Background Light').getCharacteristic('Brightness').value).toBe(26)
+    expect(accessory.getService('Main Light').getCharacteristic('Brightness').value).toBe(70)
+  })
+
+  it('keeps the two zones apart', () => {
+    const { accessory, device } = build('H1250', { useAwsControl: true })
+    device.initialised = true
+
+    device.externalUpdate({ commands: [...RING_PAGES, MAIN_PAGE], source: 'AWS' })
+
+    // The ring is blue and the main panel green, so their hues must differ -
+    // reading one zone's color off the other's segments is the failure here
+    const ringHue = accessory.getService('Background Light').getCharacteristic('Hue').value
+    const mainHue = accessory.getService('Main Light').getCharacteristic('Hue').value
+    expect(ringHue).not.toBe(mainHue)
+  })
+
+  it('ignores the padding on the last page', () => {
+    // Page 5 describes segment 16 and then pads with zeroes. Reading those as
+    // real segments would report three phantom black segments
+    const { device } = build('H1250', { useAwsControl: true })
+    device.initialised = true
+
+    device.externalUpdate({ commands: [MAIN_PAGE], source: 'AWS' })
+
+    expect(device.zoneBrightCache.mainLightToggle).toBe(70)
+  })
+
+  it('does not disable adaptive lighting on the very first report after startup', () => {
+    // zoneColourCache is seeded at construction from the tile's own restored
+    // characteristics. Without that, an unseeded cache would make the first
+    // report after every restart look like an external change - since there
+    // is nothing to compare against - and switch adaptive lighting off before
+    // anything had actually changed
+    const { device } = build('H1250', { useAwsControl: true })
+    device.initialised = true
+    const disable = vi.fn()
+    device.zoneAlControllers.mainLightToggle = {
+      isAdaptiveLightingActive: () => true,
+      disableAdaptiveLighting: disable,
+    }
+
+    // Reports back exactly the color the cache was already seeded with
+    const seeded = device.zoneColourCache.mainLightToggle
+    const level = device.zoneBrightCache.mainLightToggle
+    const buf = Buffer.alloc(20)
+    Buffer.from([0xAA, 0xA5, 0x05, level, seeded.r, seeded.g, seeded.b]).copy(buf)
+    let checksum = 0
+    for (let index = 0; index < 19; index += 1) {
+      checksum ^= buf[index]
+    }
+    buf[19] = checksum
+
+    device.externalUpdate({ commands: [buf.toString('base64')], source: 'AWS' })
+
+    expect(disable).not.toHaveBeenCalled()
   })
 })

--- a/lib/device/light-zones.test.js
+++ b/lib/device/light-zones.test.js
@@ -129,3 +129,23 @@ describe('every other light', () => {
     expect(accessory.getService('Main Light').getCharacteristic('On').value).toBe(true)
   })
 })
+
+describe('a two-zone light\'s segment layout', () => {
+  it('knows which segments belong to which zone', () => {
+    const { device } = build('H1250', { useAwsControl: true })
+
+    expect(device.zoneSegments.main).toEqual([16])
+    // Written as a literal rather than re-deriving the range: a duplicated or
+    // reordered interior segment, or segment 16 leaking into this list, would
+    // still pass a length-and-endpoints check but is exactly the kind of bug
+    // this layout exists to prevent - segment 16 belonging to both zones would
+    // mean setting the background silently repaints the main panel too
+    expect(device.zoneSegments.background).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+  })
+
+  it('leaves a model with no layout alone', () => {
+    const { device } = build('H6102', { useAwsControl: true })
+
+    expect(device.hasRawZones).toBe(false)
+  })
+})

--- a/lib/device/light.js
+++ b/lib/device/light.js
@@ -503,6 +503,52 @@ export default class extends GoveeDevice {
     }
   }
 
+  /**
+   * Sets one zone's brightness in response to a HomeKit write.
+   *
+   * @param {string} instance the capability instance, eg 'mainLightToggle'
+   * @param {string} zone the key into `this.zoneLightSegments`, eg 'main'
+   * @param {string} name the tile's display name, for logging
+   * @param {number} value 0-100
+   */
+  async internalZoneBrightnessUpdate(instance, zone, name, value) {
+    const service = this.zoneServices[instance]
+    try {
+      // HomeKit writes once per position of the slider, so without this a single
+      // drag becomes a burst of frames. Same debounce the main light uses
+      const updateKey = generateRandomString(5)
+      this.zoneUpdateKey[instance] = updateKey
+      await sleep(350)
+      if (updateKey !== this.zoneUpdateKey[instance]) {
+        return
+      }
+
+      // Don't continue if the new value is the same as before
+      if (this.zoneBrightCache[instance] === value) {
+        return
+      }
+
+      await this.platform.sendDeviceUpdate(this.accessory, {
+        cmd: 'zoneBrightness',
+        lightSegments: this.zoneLightSegments[zone],
+        value,
+      })
+
+      this.zoneBrightCache[instance] = value
+      this.accessory.log(`[${name}] ${platformLang.curBright} [${value}%]`)
+    } catch (err) {
+      this.accessory.logWarn(`[${name}] ${platformLang.devNotUpdated} ${parseError(err)}`)
+
+      // Throw a 'no response' error and revert this after 2 seconds
+      setTimeout(() => {
+        if (service) {
+          service.updateCharacteristic(this.hapChar.Brightness, this.zoneBrightCache[instance])
+        }
+      }, 2000)
+      throw new this.hapErr(-70402)
+    }
+  }
+
   async internalBrightnessUpdate(value) {
     try {
       // This acts like a debounce function when endlessly sliding the brightness scale

--- a/lib/device/light.js
+++ b/lib/device/light.js
@@ -44,6 +44,42 @@ function readZoneFrame(commands = []) {
 }
 
 /**
+ * The brightness and color a two-zone light reports for every one of its
+ * light segments, as `aa a5 <page>` followed by four groups of
+ * `<level> <r> <g> <b>`.
+ *
+ * Pages run from 01 and each covers four light segments, so page N describes
+ * segments (N-1)*4 upward. A light whose segment count is not a multiple of
+ * four pads the last page with zeroes, and those are skipped rather than
+ * reported as black segments that do not exist (#1333).
+ *
+ * @param {string[]} [commands] the base64 frames from the payload
+ * @returns {object} what each light segment reported, keyed by segment number
+ */
+function readLightSegmentFrames(commands = []) {
+  const lightSegments = {}
+  commands.forEach((command) => {
+    const hexParts = hexToTwoItems(base64ToHex(command))
+    if (`${getTwoItemPosition(hexParts, 1)}${getTwoItemPosition(hexParts, 2)}` !== 'aaa5') {
+      return
+    }
+    const page = Number.parseInt(getTwoItemPosition(hexParts, 3), 16)
+    for (let group = 0; group < 4; group += 1) {
+      const at = 4 + (group * 4)
+      const level = Number.parseInt(getTwoItemPosition(hexParts, at), 16)
+      const r = Number.parseInt(getTwoItemPosition(hexParts, at + 1), 16)
+      const g = Number.parseInt(getTwoItemPosition(hexParts, at + 2), 16)
+      const b = Number.parseInt(getTwoItemPosition(hexParts, at + 3), 16)
+      if (level === 0 && r === 0 && g === 0 && b === 0) {
+        continue
+      }
+      lightSegments[((page - 1) * 4) + group] = { level, r, g, b }
+    }
+  })
+  return lightSegments
+}
+
+/**
  * The two zones a light of this kind has. Fixed, unlike which light segments
  * each one owns, which varies by model - see `zoneLightModels` in constants.js.
  */
@@ -360,6 +396,22 @@ export default class extends GoveeDevice {
             .onSet(async value => this.internalZoneColourUpdate(instance, zone, name, value))
           service.getCharacteristic(this.hapChar.Saturation)
           this.zoneBrightCache[instance] = service.getCharacteristic(this.hapChar.Brightness).value
+
+          // Seed this now, not just on the first write or status report. An
+          // unseeded cache would make externalUpdate's "did this change
+          // elsewhere" check treat the very first report after every restart
+          // as an external change - switching adaptive lighting off before
+          // anything has actually changed
+          const seedHue = service.getCharacteristic(this.hapChar.Hue).value
+          const seedSat = service.getCharacteristic(this.hapChar.Saturation).value
+          const [seedR, seedG, seedB] = hs2rgb(seedHue, seedSat)
+          this.zoneColourCache[instance] = {
+            r: seedR,
+            g: seedG,
+            b: seedB,
+            hue: seedHue,
+            sat: seedSat,
+          }
 
           // Adaptive lighting needs Brightness and ColorTemperature on the same
           // service, so a zone that is to have it needs its own color
@@ -1048,6 +1100,69 @@ export default class extends GoveeDevice {
             this.zoneCache[instance] = newValue
             service.updateCharacteristic(this.hapChar.On, newValue === 1)
             this.accessory.log(`[${service.displayName}] ${platformLang.curState} [${newValue === 1 ? 'on' : 'off'}]`)
+          }
+        }
+      })
+    }
+
+    // The same status carries every light segment's brightness and color, so a
+    // change made in the Govee app, on a remote or at the wall reaches the
+    // zone tiles too - not just our own writes echoing back
+    if (this.hasRawZones) {
+      const lightSegments = readLightSegmentFrames(params.commands)
+      ZONE_DEFS.forEach(({ instance, zone, name }) => {
+        const service = this.zoneServices[instance]
+        if (!service) {
+          return
+        }
+
+        // Every light segment in a zone normally holds the same value. Where
+        // they differ - someone has colored segments individually in the
+        // Govee app - the first is what the tile shows, because HomeKit has
+        // one value per characteristic and this zone has sixteen segments
+        const first = this.zoneLightSegments[zone].find(index => lightSegments[index])
+        const reported = first === undefined ? undefined : lightSegments[first]
+        if (!reported) {
+          return
+        }
+
+        if (this.zoneBrightCache[instance] !== reported.level) {
+          this.zoneBrightCache[instance] = reported.level
+          service.updateCharacteristic(this.hapChar.Brightness, reported.level)
+          this.accessory.log(`[${name}] ${platformLang.curBright} [${reported.level}%]`)
+        }
+
+        const cached = this.zoneColourCache[instance]
+        if (!cached || cached.r !== reported.r || cached.g !== reported.g || cached.b !== reported.b) {
+          const [hue, sat] = rgb2hs(reported.r, reported.g, reported.b)
+
+          // A zone repeating our own command back can drift by a unit or two
+          // through the conversions on the way out and back. Beyond that
+          // drift, somebody else set this color
+          const changedElsewhere = !cached
+            || Math.abs(reported.r - cached.r) > 5
+            || Math.abs(reported.g - cached.g) > 5
+            || Math.abs(reported.b - cached.b) > 5
+
+          this.zoneColourCache[instance] = {
+            r: reported.r,
+            g: reported.g,
+            b: reported.b,
+            hue,
+            sat,
+          }
+          service.updateCharacteristic(this.hapChar.Hue, hue)
+          service.updateCharacteristic(this.hapChar.Saturation, sat)
+          this.accessory.log(`[${name}] ${platformLang.curColour} [rgb ${reported.r} ${reported.g} ${reported.b}]`)
+
+          // Somebody chose this color in the Govee app, on a remote or at the
+          // wall. Homebridge catches HomeKit's own writes, but nothing sees
+          // these - so this zone's adaptive lighting would carry on and move
+          // it back off that color within minutes (#1333)
+          const controller = this.zoneAlControllers[instance]
+          if (changedElsewhere && controller?.isAdaptiveLightingActive?.()) {
+            controller.disableAdaptiveLighting()
+            this.accessory.log(`[${name}] ${platformLang.alDisabled}`)
           }
         }
       })

--- a/lib/device/light.js
+++ b/lib/device/light.js
@@ -256,7 +256,8 @@ export default class extends GoveeDevice {
     // a failure is undone are the same either way (#1333)
     this.zoneServices = {}
     this.zoneCache = {}
-    this.hasRawZones = platformConsts.zoneLightModels.includes(accessory.context.gvModel)
+    this.zoneSegments = platformConsts.zoneLightModels[accessory.context.gvModel]
+    this.hasRawZones = Boolean(this.zoneSegments)
     const zoneToggleDefs = [
       { instance: 'mainLightToggle', zone: 'main', name: 'Main Light' },
       { instance: 'backgroundLightToggle', zone: 'background', name: 'Background Light' },

--- a/lib/device/light.js
+++ b/lib/device/light.js
@@ -549,6 +549,74 @@ export default class extends GoveeDevice {
     }
   }
 
+  /**
+   * Sets one zone's color in response to a HomeKit hue write. Saturation is
+   * read from the tile itself, since HomeKit sends hue and saturation as
+   * separate writes.
+   *
+   * @param {string} instance the capability instance, eg 'mainLightToggle'
+   * @param {string} zone the key into `this.zoneLightSegments`, eg 'main'
+   * @param {string} name the tile's display name, for logging
+   * @param {number} value hue, 0-360
+   */
+  async internalZoneColourUpdate(instance, zone, name, value) {
+    const service = this.zoneServices[instance]
+    try {
+      // Same debounce as the main light's colour wheel
+      const updateKey = generateRandomString(5)
+      this.zoneUpdateKey[instance] = updateKey
+      await sleep(300)
+      if (updateKey !== this.zoneUpdateKey[instance]) {
+        return
+      }
+
+      // Dropping the cct to its lowest mimics native adaptive lighting, and
+      // HAP asks for it on any service carrying both hue/saturation and color
+      // temperature. The main light does the same
+      if (!this.colourSafeMode) {
+        service.updateCharacteristic(this.hapChar.ColorTemperature, 140)
+      }
+
+      // Hue and saturation arrive as separate writes, so the other half comes
+      // from this tile's own characteristic - not the main light's
+      const currentSat = service.getCharacteristic(this.hapChar.Saturation).value
+      const [r, g, b] = hs2rgb(value, currentSat)
+
+      // Don't continue if the new value is the same as before
+      const cached = this.zoneColourCache[instance]
+      if (cached && cached.r === r && cached.g === g && cached.b === b) {
+        return
+      }
+
+      await this.platform.sendDeviceUpdate(this.accessory, {
+        cmd: 'zoneColour',
+        lightSegments: this.zoneLightSegments[zone],
+        value: { r, g, b },
+      })
+
+      this.zoneColourCache[instance] = {
+        r,
+        g,
+        b,
+        hue: value,
+        sat: currentSat,
+      }
+      this.accessory.log(`[${name}] ${platformLang.curColour} [rgb ${r} ${g} ${b}]`)
+    } catch (err) {
+      this.accessory.logWarn(`[${name}] ${platformLang.devNotUpdated} ${parseError(err)}`)
+
+      // Throw a 'no response' error and revert this after 2 seconds
+      setTimeout(() => {
+        const previous = this.zoneColourCache[instance]
+        if (service && previous) {
+          service.updateCharacteristic(this.hapChar.Hue, previous.hue)
+          service.updateCharacteristic(this.hapChar.Saturation, previous.sat)
+        }
+      }, 2000)
+      throw new this.hapErr(-70402)
+    }
+  }
+
   async internalBrightnessUpdate(value) {
     try {
       // This acts like a debounce function when endlessly sliding the brightness scale

--- a/lib/device/light.js
+++ b/lib/device/light.js
@@ -43,6 +43,39 @@ function readZoneFrame(commands = []) {
   return zones
 }
 
+/**
+ * The two zones a light of this kind has. Fixed, unlike which light segments
+ * each one owns, which varies by model - see `zoneLightModels` in constants.js.
+ */
+const ZONE_DEFS = [
+  { instance: 'mainLightToggle', zone: 'main', name: 'Main Light' },
+  { instance: 'backgroundLightToggle', zone: 'background', name: 'Background Light' },
+]
+
+/**
+ * Real HAP's AdaptiveLightingController adds these three characteristics to
+ * the service it attaches to. When adaptive lighting has just been switched
+ * off, only these need to go - the whole Lightbulb service used to be thrown
+ * away and rebuilt here, which does hide the icon but presents Home with what
+ * looks like a different light, and an owner can lose that light's room and
+ * its automations as a result.
+ *
+ * @param {object} service the HAP service to remove the characteristics from
+ * @param {object} hapChar the platform's Characteristic lookup
+ */
+function clearAdaptiveLightingCharacteristics(service, hapChar) {
+  [
+    'SupportedCharacteristicValueTransitionConfiguration',
+    'CharacteristicValueTransitionControl',
+    'CharacteristicValueActiveTransitionCount',
+  ].forEach((charName) => {
+    const char = hapChar[charName]
+    if (char && service.testCharacteristic(char)) {
+      service.removeCharacteristic(service.getCharacteristic(char))
+    }
+  })
+}
+
 export default class extends GoveeDevice {
   constructor(platform, accessory) {
     super(platform, accessory)
@@ -78,16 +111,7 @@ export default class extends GoveeDevice {
     // the icon but presents Home with what looks like a different light, and an
     // owner can lose that light's room and its automations as a result.
     if ((this.colourSafeMode || this.alShift === -1) && this.accessory.context.adaptiveLighting) {
-      [
-        'SupportedCharacteristicValueTransitionConfiguration',
-        'CharacteristicValueTransitionControl',
-        'CharacteristicValueActiveTransitionCount',
-      ].forEach((charName) => {
-        const char = this.hapChar[charName]
-        if (char && this.service.testCharacteristic(char)) {
-          this.service.removeCharacteristic(this.service.getCharacteristic(char))
-        }
-      })
+      clearAdaptiveLightingCharacteristics(this.service, this.hapChar)
       this.accessory.context.adaptiveLighting = false
     }
 
@@ -247,42 +271,128 @@ export default class extends GoveeDevice {
 
     // Some lights (e.g. the H1270 Ceiling Light Ultra) have two independently
     // controllable zones - a main/bottom panel and a background/top light. Govee
-    // exposes these as OpenAPI toggle capabilities, so add a switch for each zone
-    // the device reports, controlled over the OpenAPI connection.
+    // exposes these as OpenAPI toggle capabilities, so add a lightbulb for each
+    // zone the device reports, controlled over the OpenAPI connection.
     //
     // The models in `zoneLightModels` advertise those same capabilities but the
     // cloud never delivers them, so they are driven by a raw frame over AWS
-    // instead. That is the only difference - the tiles, their state and the way
-    // a failure is undone are the same either way (#1333)
+    // instead - and only those models can address a zone's brightness and
+    // color, since the raw frame reaches light segments the OpenAPI toggle
+    // capabilities never could. Either way the tile itself, its state and how
+    // a failure is undone are the same (#1333)
     this.zoneServices = {}
     this.zoneCache = {}
-    this.zoneSegments = platformConsts.zoneLightModels[accessory.context.gvModel]
-    this.hasRawZones = Boolean(this.zoneSegments)
-    const zoneToggleDefs = [
-      { instance: 'mainLightToggle', zone: 'main', name: 'Main Light' },
-      { instance: 'backgroundLightToggle', zone: 'background', name: 'Background Light' },
-    ]
+    // "light segments" to avoid any confusion with the unrelated
+    // segmented/segmentedTwo/segmentedThree/segmentedFour config options
+    // elsewhere in this file, which name a captured scene or BLE code
+    this.zoneLightSegments = platformConsts.zoneLightModels[accessory.context.gvModel]
+    this.hasRawZones = Boolean(this.zoneLightSegments)
+    this.zoneBrightCache = {}
+    this.zoneColourCache = {}
+    this.zoneMiredCache = {}
+    this.zoneUpdateKey = {}
+    this.zoneAlControllers = {}
     const openApiCaps = accessory.context.openApiCapabilities || {}
-    zoneToggleDefs.forEach(({ instance, zone, name }) => {
-      const existingService = this.accessory.getService(name)
+    ZONE_DEFS.forEach(({ instance, zone, name }) => {
+      // A real HAP Service has no `.type` - only `.UUID`, `.subtype` and
+      // `.displayName` - so getServiceById is the correct way to ask "does this
+      // zone's lightbulb already exist", matching by type AND subtype rather
+      // than by name. Falling back to a name lookup only when that comes up
+      // empty catches a service under this name that ISN'T this lightbulb,
+      // which can only be the tile's previous Switch, since HomeKit cannot
+      // change a service's type in place
+      const existingLightbulb = this.accessory.getServiceById(this.hapServ.Lightbulb, instance)
+      let existingService = existingLightbulb || this.accessory.getService(name)
 
       // The raw frame goes over AWS, which needs Govee account credentials
-      // rather than just an API key
+      // rather than just an API key. For raw-zone models, also require this
+      // particular zone to have a measured light segment layout - a model
+      // whose config only defines one of its two zones should not offer a
+      // tile for the other one, since every raw-zone handler indexes
+      // zoneLightSegments[zone] and would throw at tap time on a real device
+      // rather than at startup
       const isControllable = this.hasRawZones
-        ? accessory.context.useAwsControl
+        ? accessory.context.useAwsControl && Boolean(this.zoneLightSegments[zone])
         : accessory.context.useOpenApiControl && openApiCaps[instance]
 
       if (isControllable) {
+        // That name-matched fallback is stale (the old Switch) whenever it
+        // isn't the lightbulb itself - clear it out before the lightbulb can
+        // take the name, otherwise the tile is stuck with On and nothing
+        // else, and no amount of adding characteristics will fix it
+        if (existingService && existingService !== existingLightbulb) {
+          this.accessory.removeService(existingService)
+          existingService = undefined
+        }
+
         const service = existingService
-          || this.accessory.addService(this.hapServ.Switch, name, instance)
+          || this.accessory.addService(this.hapServ.Lightbulb, name, instance)
         service
           .getCharacteristic(this.hapChar.On)
           .onSet(async value => this.internalZoneUpdate(instance, zone, name, value))
+
+        // Only the raw-frame models can address a zone's brightness and color.
+        // The models whose toggles work have on/off and nothing else, so giving
+        // them sliders would be a control that silently does nothing - which is
+        // the bug this whole path exists to avoid (#1333)
+        if (this.hasRawZones) {
+          // Adaptive lighting characteristics are added to a service by real
+          // HAP's AdaptiveLightingController when it attaches, not by this
+          // file, so they can only be sitting on a zone service left over from
+          // an earlier boot that had a controller here. Zones have no
+          // equivalent of `accessory.context.adaptiveLighting` above - that
+          // flag exists purely to remember, for the MAIN light, that this
+          // block already ran once so it does not repeat needlessly. A zone's
+          // controller is fully re-derived from colourSafeMode/alShift on
+          // every boot regardless (see below), so there is nothing to
+          // remember here: checking those two directly is enough to know
+          // whether this boot's controller state has changed from the last
+          if (this.colourSafeMode || this.alShift === -1) {
+            clearAdaptiveLightingCharacteristics(service, this.hapChar)
+          }
+
+          service
+            .getCharacteristic(this.hapChar.Brightness)
+            .setProps({ minStep: this.brightStep })
+            .onSet(async value => this.internalZoneBrightnessUpdate(instance, zone, name, value))
+          service
+            .getCharacteristic(this.hapChar.Hue)
+            .onSet(async value => this.internalZoneColourUpdate(instance, zone, name, value))
+          service.getCharacteristic(this.hapChar.Saturation)
+          this.zoneBrightCache[instance] = service.getCharacteristic(this.hapChar.Brightness).value
+
+          // Adaptive lighting needs Brightness and ColorTemperature on the same
+          // service, so a zone that is to have it needs its own color
+          // temperature control. The zone only takes rgb on the wire, so a
+          // temperature is converted on the way out - the same thing the
+          // bluetooth path already does for every other light
+          if (this.colourSafeMode) {
+            if (service.testCharacteristic(this.hapChar.ColorTemperature)) {
+              service.removeCharacteristic(service.getCharacteristic(this.hapChar.ColorTemperature))
+            }
+            this.zoneMiredCache[instance] = 0
+          } else {
+            service
+              .getCharacteristic(this.hapChar.ColorTemperature)
+              .onSet(async value => this.internalZoneCTUpdate(instance, zone, name, value))
+            this.zoneMiredCache[instance] = service.getCharacteristic(this.hapChar.ColorTemperature).value
+
+            // One controller per zone. The id is derived from the service, so
+            // these sit alongside the main light's rather than clashing with it
+            if (this.alShift !== -1) {
+              this.zoneAlControllers[instance] = new platform.api.hap.AdaptiveLightingController(service, {
+                customTemperatureAdjustment: this.alShift,
+              })
+              this.accessory.configureController(this.zoneAlControllers[instance])
+            }
+          }
+        }
+
         this.zoneServices[instance] = service
         this.zoneCache[instance] = service.getCharacteristic(this.hapChar.On).value ? 1 : 0
       } else if (existingService) {
         // Capability no longer available (or the connection it needs is off) so
-        // remove the switch
+        // remove the tile
         this.accessory.removeService(existingService)
       }
     })

--- a/lib/device/light.js
+++ b/lib/device/light.js
@@ -326,6 +326,7 @@ export default class extends GoveeDevice {
     this.zoneBrightCache = {}
     this.zoneColourCache = {}
     this.zoneMiredCache = {}
+    this.zoneKelvinCache = {}
     this.zoneUpdateKey = {}
     this.zoneAlControllers = {}
     const openApiCaps = accessory.context.openApiCapabilities || {}
@@ -423,11 +424,19 @@ export default class extends GoveeDevice {
               service.removeCharacteristic(service.getCharacteristic(this.hapChar.ColorTemperature))
             }
             this.zoneMiredCache[instance] = 0
+            this.zoneKelvinCache[instance] = 0
           } else {
             service
               .getCharacteristic(this.hapChar.ColorTemperature)
               .onSet(async value => this.internalZoneCTUpdate(instance, zone, name, value))
             this.zoneMiredCache[instance] = service.getCharacteristic(this.hapChar.ColorTemperature).value
+
+            // Seeded the same way as the mired cache above, so the first real
+            // adaptive lighting tick after a restart is compared against what
+            // was actually last sent, not against nothing
+            const seedMired = this.zoneMiredCache[instance]
+            const seedKelvin = Math.round(1000000 / seedMired / 100) * 100
+            this.zoneKelvinCache[instance] = Math.min(Math.max(seedKelvin, this.minKelvin), this.maxKelvin)
 
             // One controller per zone. The id is derived from the service, so
             // these sit alongside the main light's rather than clashing with it
@@ -690,8 +699,16 @@ export default class extends GoveeDevice {
         return
       }
 
-      // Don't continue if the new value is the same as before
-      if (this.zoneMiredCache[instance] === value) {
+      // Convert mired to kelvin to nearest 100, the same rounding the main
+      // light uses. Adaptive lighting nudges mired by fractional amounts far
+      // more often than the rounded kelvin actually changes, so comparing the
+      // rounded value below - not raw mired - is what keeps a real command
+      // from going out on almost every adaptive lighting tick
+      const kelvin = Math.round(1000000 / value / 100) * 100
+      const k = Math.min(Math.max(kelvin, this.minKelvin), this.maxKelvin)
+
+      // Don't continue if the rounded kelvin is the same as before
+      if (this.zoneKelvinCache[instance] === k) {
         return
       }
 
@@ -703,8 +720,7 @@ export default class extends GoveeDevice {
 
       // The zone frame carries rgb and nothing else, so the temperature is
       // converted here - the same conversion the bluetooth path uses
-      const kelvin = Math.round(1000000 / value)
-      const [r, g, b] = k2rgb(kelvin)
+      const [r, g, b] = k2rgb(k)
 
       await this.platform.sendDeviceUpdate(this.accessory, {
         cmd: 'zoneColour',
@@ -712,6 +728,7 @@ export default class extends GoveeDevice {
         value: { r, g, b },
       })
 
+      this.zoneKelvinCache[instance] = k
       this.zoneMiredCache[instance] = value
       this.zoneColourCache[instance] = {
         r,
@@ -720,7 +737,7 @@ export default class extends GoveeDevice {
         hue,
         sat,
       }
-      this.accessory.log(`[${name}] ${platformLang.curColour} [${kelvin}K / ${value}M]`)
+      this.accessory.log(`[${name}] ${platformLang.curColour} [${k}K / ${value}M]`)
     } catch (err) {
       this.accessory.logWarn(`[${name}] ${platformLang.devNotUpdated} ${parseError(err)}`)
 

--- a/lib/device/light.js
+++ b/lib/device/light.js
@@ -617,6 +617,71 @@ export default class extends GoveeDevice {
     }
   }
 
+  /**
+   * Sets one zone's color temperature. Adaptive lighting calls this on its own
+   * schedule; a HomeKit write reaches it the same way.
+   *
+   * @param {string} instance the capability instance, eg 'mainLightToggle'
+   * @param {string} zone the key into `this.zoneLightSegments`, eg 'main'
+   * @param {string} name the tile's display name, for logging
+   * @param {number} value mireds
+   */
+  async internalZoneCTUpdate(instance, zone, name, value) {
+    const service = this.zoneServices[instance]
+    try {
+      // Adaptive lighting writes here every sixty seconds, so this is debounced
+      // exactly as the main light's color temperature is
+      const updateKey = generateRandomString(5)
+      this.zoneUpdateKey[instance] = updateKey
+      await sleep(300)
+      if (updateKey !== this.zoneUpdateKey[instance]) {
+        return
+      }
+
+      // Don't continue if the new value is the same as before
+      if (this.zoneMiredCache[instance] === value) {
+        return
+      }
+
+      // Updating hue/sat to the corresponding values mimics native adaptive
+      // lighting - the main light's own color temperature handler does the same
+      const [hue, sat] = m2hs(value)
+      service.updateCharacteristic(this.hapChar.Hue, hue)
+      service.updateCharacteristic(this.hapChar.Saturation, sat)
+
+      // The zone frame carries rgb and nothing else, so the temperature is
+      // converted here - the same conversion the bluetooth path uses
+      const kelvin = Math.round(1000000 / value)
+      const [r, g, b] = k2rgb(kelvin)
+
+      await this.platform.sendDeviceUpdate(this.accessory, {
+        cmd: 'zoneColour',
+        lightSegments: this.zoneLightSegments[zone],
+        value: { r, g, b },
+      })
+
+      this.zoneMiredCache[instance] = value
+      this.zoneColourCache[instance] = {
+        r,
+        g,
+        b,
+        hue,
+        sat,
+      }
+      this.accessory.log(`[${name}] ${platformLang.curColour} [${kelvin}K / ${value}M]`)
+    } catch (err) {
+      this.accessory.logWarn(`[${name}] ${platformLang.devNotUpdated} ${parseError(err)}`)
+
+      // Throw a 'no response' error and revert this after 2 seconds
+      setTimeout(() => {
+        if (service) {
+          service.updateCharacteristic(this.hapChar.ColorTemperature, this.zoneMiredCache[instance])
+        }
+      }, 2000)
+      throw new this.hapErr(-70402)
+    }
+  }
+
   async internalBrightnessUpdate(value) {
     try {
       // This acts like a debounce function when endlessly sliding the brightness scale

--- a/lib/utils/command-builder.js
+++ b/lib/utils/command-builder.js
@@ -28,6 +28,8 @@ export function buildCommand(params, context) {
       return buildOpenApiCommand(params)
     case 'zoneState':
       return buildZoneStateCommand(params)
+    case 'zoneColour':
+      return buildZoneColourCommand(params)
     case 'brightness':
       return buildBrightnessCommand(params, context)
     case 'color':
@@ -141,6 +143,78 @@ function buildZoneStateCommand(params) {
     awsParams: {
       cmd: 'ptReal',
       data: { command: [generateCodeFromHexValues([0x33, 0x30, zone, params.value ? 0x01 : 0x00])] },
+    },
+  }
+}
+
+/**
+ * A zone is addressed by a bitmask over the light's segments, three bytes wide,
+ * least significant byte first. Two bytes is what every other model in the
+ * plugin uses, and is exactly why nothing ever reached the H1250's main panel -
+ * that light has seventeen segments and the seventeenth bit lives in the third
+ * byte (#1333).
+ *
+ * @param {number[]} segments the segment indices to address (0-23)
+ * @returns {number[]} a 3-byte mask, least significant byte first
+ */
+function segmentMask(segments) {
+  const mask = [0x00, 0x00, 0x00]
+  if (!segments.length) {
+    throw new Error('No segments given for a zone command')
+  }
+  segments.forEach((segment) => {
+    if (!Number.isInteger(segment) || segment < 0 || segment > 23) {
+      // Past 23 the mask array silently grows a fourth byte, which shifts every
+      // byte after it and still checksums cleanly - a wrong frame the device
+      // accepts is far harder to spot than an outright failure
+      throw new Error(`Segment [${segment}] is outside the three-byte mask`)
+    }
+    mask[Math.floor(segment / 8)] |= 1 << (segment % 8)
+  })
+  return mask
+}
+
+/**
+ * Builds the `ptReal` frame that sets color on one or more zones of an H1250.
+ *
+ * Color pads to put the mask at bytes 12-14. Brightness puts it straight after
+ * the level, at bytes 5-7. The two layouts really do differ - assuming
+ * brightness matched color is what made every early attempt at it fail.
+ *
+ * @param {object} params the command params
+ * @param {object} params.value
+ * @param {number} params.value.r 0-255
+ * @param {number} params.value.g 0-255
+ * @param {number} params.value.b 0-255
+ * @param {number[]} params.segments the segment indices to address
+ * @returns {{ awsParams: object }} the AWS-only command params
+ */
+function buildZoneColourCommand(params) {
+  if (!params.value || !params.segments) {
+    throw new Error(`Missing value or segments for ${params.cmd}`)
+  }
+  const { r, g, b } = params.value
+  return {
+    // AWS only, for the same reason as buildZoneStateCommand
+    awsParams: {
+      cmd: 'ptReal',
+      data: {
+        command: [generateCodeFromHexValues([
+          0x33,
+          0x05,
+          0x15,
+          0x01,
+          r,
+          g,
+          b,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          ...segmentMask(params.segments),
+        ])],
+      },
     },
   }
 }

--- a/lib/utils/command-builder.js
+++ b/lib/utils/command-builder.js
@@ -30,6 +30,8 @@ export function buildCommand(params, context) {
       return buildZoneStateCommand(params)
     case 'zoneColour':
       return buildZoneColourCommand(params)
+    case 'zoneBrightness':
+      return buildZoneBrightnessCommand(params)
     case 'brightness':
       return buildBrightnessCommand(params, context)
     case 'color':
@@ -212,6 +214,47 @@ function buildZoneColourCommand(params) {
           0x00,
           0x00,
           0x00,
+          ...segmentMask(params.segments),
+        ])],
+      },
+    },
+  }
+}
+
+/**
+ * The frame that sets a zone's brightness.
+ *
+ * Sent as-is, with no 0-254 scaling like `buildBrightnessCommand` applies for
+ * the whole-device AWS command - this is deliberate, not an oversight. The zone
+ * frame's level byte is already 0-100, the same scale HomeKit uses.
+ *
+ * @param {object} params
+ * @param {number[]} params.segments the segment indices to set
+ * @param {number} params.value 0-100, the same scale HomeKit uses
+ * @returns {{ awsParams: object }} the raw frame to send over AWS -
+ *   for the same reason as `buildZoneColourCommand`, this device does not
+ *   get a LAN path
+ */
+function buildZoneBrightnessCommand(params) {
+  if (params.value === undefined || !params.segments) {
+    throw new Error(`Missing value or segments for ${params.cmd}`)
+  }
+  if (!Number.isInteger(params.value) || params.value < 0 || params.value > 100) {
+    // Out of range the byte silently wraps - 300 becomes 44 - and the frame
+    // still checksums cleanly, so the light takes a brightness nobody asked
+    // for rather than the command failing outright
+    throw new Error(`Brightness [${params.value}] is outside 0-100 for ${params.cmd}`)
+  }
+  return {
+    awsParams: {
+      cmd: 'ptReal',
+      data: {
+        command: [generateCodeFromHexValues([
+          0x33,
+          0x05,
+          0x15,
+          0x02,
+          params.value,
           ...segmentMask(params.segments),
         ])],
       },

--- a/lib/utils/command-builder.js
+++ b/lib/utils/command-builder.js
@@ -150,28 +150,32 @@ function buildZoneStateCommand(params) {
 }
 
 /**
- * A zone is addressed by a bitmask over the light's segments, three bytes wide,
- * least significant byte first. Two bytes is what every other model in the
- * plugin uses, and is exactly why nothing ever reached the H1250's main panel -
- * that light has seventeen segments and the seventeenth bit lives in the third
- * byte (#1333).
+ * A zone is addressed by a bitmask over the light's individually-addressable
+ * segments, three bytes wide, least significant byte first. Called "light
+ * segments" throughout, distinct from the unrelated `segmented`/`segmentedTwo`/
+ * etc. config options elsewhere in this plugin, which name a captured scene or
+ * BLE code and have nothing to do with per-segment addressing.
  *
- * @param {number[]} segments the segment indices to address (0-23)
+ * Two bytes is what every other model in the plugin uses, and is exactly why
+ * nothing ever reached the H1250's main panel - that light has seventeen light
+ * segments and the seventeenth bit lives in the third byte (#1333).
+ *
+ * @param {number[]} lightSegments the light segment indices to address (0-23)
  * @returns {number[]} a 3-byte mask, least significant byte first
  */
-function segmentMask(segments) {
+function lightSegmentMask(lightSegments) {
   const mask = [0x00, 0x00, 0x00]
-  if (!segments.length) {
-    throw new Error('No segments given for a zone command')
+  if (!lightSegments.length) {
+    throw new Error('No light segments given for a zone command')
   }
-  segments.forEach((segment) => {
-    if (!Number.isInteger(segment) || segment < 0 || segment > 23) {
+  lightSegments.forEach((lightSegment) => {
+    if (!Number.isInteger(lightSegment) || lightSegment < 0 || lightSegment > 23) {
       // Past 23 the mask array silently grows a fourth byte, which shifts every
       // byte after it and still checksums cleanly - a wrong frame the device
       // accepts is far harder to spot than an outright failure
-      throw new Error(`Segment [${segment}] is outside the three-byte mask`)
+      throw new Error(`Light segment [${lightSegment}] is outside the three-byte mask`)
     }
-    mask[Math.floor(segment / 8)] |= 1 << (segment % 8)
+    mask[Math.floor(lightSegment / 8)] |= 1 << (lightSegment % 8)
   })
   return mask
 }
@@ -188,12 +192,12 @@ function segmentMask(segments) {
  * @param {number} params.value.r 0-255
  * @param {number} params.value.g 0-255
  * @param {number} params.value.b 0-255
- * @param {number[]} params.segments the segment indices to address
+ * @param {number[]} params.lightSegments the light segment indices to address
  * @returns {{ awsParams: object }} the AWS-only command params
  */
 function buildZoneColourCommand(params) {
-  if (!params.value || !params.segments) {
-    throw new Error(`Missing value or segments for ${params.cmd}`)
+  if (!params.value || !params.lightSegments) {
+    throw new Error(`Missing value or light segments for ${params.cmd}`)
   }
   const { r, g, b } = params.value
   return {
@@ -214,7 +218,7 @@ function buildZoneColourCommand(params) {
           0x00,
           0x00,
           0x00,
-          ...segmentMask(params.segments),
+          ...lightSegmentMask(params.lightSegments),
         ])],
       },
     },
@@ -229,15 +233,15 @@ function buildZoneColourCommand(params) {
  * frame's level byte is already 0-100, the same scale HomeKit uses.
  *
  * @param {object} params
- * @param {number[]} params.segments the segment indices to set
+ * @param {number[]} params.lightSegments the light segment indices to set
  * @param {number} params.value 0-100, the same scale HomeKit uses
  * @returns {{ awsParams: object }} the raw frame to send over AWS -
  *   for the same reason as `buildZoneColourCommand`, this device does not
  *   get a LAN path
  */
 function buildZoneBrightnessCommand(params) {
-  if (params.value === undefined || !params.segments) {
-    throw new Error(`Missing value or segments for ${params.cmd}`)
+  if (params.value === undefined || !params.lightSegments) {
+    throw new Error(`Missing value or light segments for ${params.cmd}`)
   }
   if (!Number.isInteger(params.value) || params.value < 0 || params.value > 100) {
     // Out of range the byte silently wraps - 300 becomes 44 - and the frame
@@ -255,7 +259,7 @@ function buildZoneBrightnessCommand(params) {
           0x15,
           0x02,
           params.value,
-          ...segmentMask(params.segments),
+          ...lightSegmentMask(params.lightSegments),
         ])],
       },
     },

--- a/lib/utils/command-builder.test.js
+++ b/lib/utils/command-builder.test.js
@@ -425,3 +425,60 @@ describe('setting a zone\'s color', () => {
     expect(result.bleParams).toBeUndefined()
   })
 })
+
+describe('setting a zone\'s brightness', () => {
+  it('puts the mask straight after the level, not where the color frame puts it', () => {
+    // Brightness is 33 05 15 02 <level> <mask>, so the mask sits at bytes 5-7.
+    // The color frame pads and puts it at 12-14. Sending brightness in the
+    // color layout does nothing at all - the light simply ignores it
+    const { awsParams } = buildCommand({ cmd: 'zoneBrightness', segments: [16], value: 70 })
+    const hex = Buffer.from(awsParams.data.command[0], 'base64').toString('hex')
+
+    expect(hex.slice(0, 8)).toBe('33051502')
+    expect(hex.slice(8, 10)).toBe('46')
+    expect(hex.slice(10, 16)).toBe('000001')
+  })
+
+  it('takes homekit\'s 0-100 without scaling', () => {
+    const { awsParams } = buildCommand({ cmd: 'zoneBrightness', segments: [0], value: 100 })
+    const hex = Buffer.from(awsParams.data.command[0], 'base64').toString('hex')
+
+    expect(hex.slice(8, 10)).toBe('64')
+  })
+
+  it('accepts a brightness of 0, which is falsy but valid', () => {
+    // A naive `!params.value` guard would reject this - 0 is a real target,
+    // not a missing one
+    const { awsParams } = buildCommand({ cmd: 'zoneBrightness', segments: [0], value: 0 })
+    const hex = Buffer.from(awsParams.data.command[0], 'base64').toString('hex')
+
+    expect(hex.slice(8, 10)).toBe('00')
+  })
+
+  it('goes over aws only', () => {
+    const result = buildCommand({ cmd: 'zoneBrightness', segments: [16], value: 30 })
+
+    expect(result.awsParams.cmd).toBe('ptReal')
+    expect(result.lanParams).toBeUndefined()
+    expect(result.openApiParams).toBeUndefined()
+    expect(result.bleParams).toBeUndefined()
+  })
+
+  it('refuses to build without a value or segments', () => {
+    expect(() => buildCommand({ cmd: 'zoneBrightness', segments: [0] }))
+      .toThrow(/value|segments/i)
+    expect(() => buildCommand({ cmd: 'zoneBrightness', value: 50 }))
+      .toThrow(/value|segments/i)
+  })
+
+  it('refuses a brightness outside 0-100', () => {
+    // Out of range the byte silently wraps instead of throwing - 300 becomes
+    // 44 in the frame, and the checksum still comes out clean
+    expect(() => buildCommand({ cmd: 'zoneBrightness', segments: [0], value: 300 }))
+      .toThrow(/brightness/i)
+    expect(() => buildCommand({ cmd: 'zoneBrightness', segments: [0], value: -1 }))
+      .toThrow(/brightness/i)
+    expect(() => buildCommand({ cmd: 'zoneBrightness', segments: [0], value: 50.5 }))
+      .toThrow(/brightness/i)
+  })
+})

--- a/lib/utils/command-builder.test.js
+++ b/lib/utils/command-builder.test.js
@@ -400,3 +400,28 @@ describe('addressing a zone by its segments', () => {
       .toThrow(/segment/i)
   })
 })
+
+describe('setting a zone\'s color', () => {
+  it('sends the frame the light accepts, with the color before the mask', () => {
+    // r/g/b are deliberately distinct (not the palindromic 0/255/0 the plan first
+    // used) so a byte-order slip - r and b swapped - fails this test instead of
+    // passing unnoticed
+    const { awsParams } = buildCommand({ cmd: 'zoneColour', segments: [16], value: { r: 1, g: 2, b: 3 } })
+    const hex = Buffer.from(awsParams.data.command[0], 'base64').toString('hex')
+
+    expect(hex.slice(0, 8)).toBe('33051501')
+    expect(hex.slice(8, 14)).toBe('010203')
+    expect(hex.slice(24, 30)).toBe('000001')
+  })
+
+  it('goes over aws only', () => {
+    // This model ignores ptReal over LAN, and LAN is fire-and-forget - offering
+    // it there would count as sent and the command would never arrive (#1333)
+    const result = buildCommand({ cmd: 'zoneColour', segments: [16], value: { r: 255, g: 0, b: 0 } })
+
+    expect(result.awsParams.cmd).toBe('ptReal')
+    expect(result.lanParams).toBeUndefined()
+    expect(result.openApiParams).toBeUndefined()
+    expect(result.bleParams).toBeUndefined()
+  })
+})

--- a/lib/utils/command-builder.test.js
+++ b/lib/utils/command-builder.test.js
@@ -346,58 +346,58 @@ describe('what goes out for a light zone', () => {
   })
 })
 
-describe('addressing a zone by its segments', () => {
+describe('addressing a zone by its light segments', () => {
   const maskBytes = hex => hex.slice(24, 30)
 
   it('puts the background ring in the first two mask bytes', () => {
     const ring = Array.from({ length: 16 }, (_, index) => index)
-    const { awsParams } = buildCommand({ cmd: 'zoneColour', segments: ring, value: { r: 255, g: 0, b: 0 } })
+    const { awsParams } = buildCommand({ cmd: 'zoneColour', lightSegments: ring, value: { r: 255, g: 0, b: 0 } })
     const hex = Buffer.from(awsParams.data.command[0], 'base64').toString('hex')
 
     expect(maskBytes(hex)).toBe('ffff00')
   })
 
-  it('puts a seventeenth segment in the third mask byte, which two bytes cannot reach', () => {
-    // The whole reason the main panel was unreachable: segment 16's bit lives
+  it('puts a seventeenth light segment in the third mask byte, which two bytes cannot reach', () => {
+    // The whole reason the main panel was unreachable: light segment 16's bit lives
     // past the two-byte mask every other model in the plugin uses
-    const { awsParams } = buildCommand({ cmd: 'zoneColour', segments: [16], value: { r: 0, g: 0, b: 255 } })
+    const { awsParams } = buildCommand({ cmd: 'zoneColour', lightSegments: [16], value: { r: 0, g: 0, b: 255 } })
     const hex = Buffer.from(awsParams.data.command[0], 'base64').toString('hex')
 
     expect(maskBytes(hex)).toBe('000001')
   })
 
-  it('refuses a segment it cannot fit in the three-byte mask', () => {
-    // A segment past 23 would silently grow the mask to a fourth byte, which
+  it('refuses a light segment it cannot fit in the three-byte mask', () => {
+    // A light segment past 23 would silently grow the mask to a fourth byte, which
     // still checksums cleanly - a wrong frame the device accepts is far harder
     // to spot than an outright failure
-    expect(() => buildCommand({ cmd: 'zoneColour', segments: [24], value: { r: 0, g: 0, b: 255 } }))
-      .toThrow(/segment/i)
+    expect(() => buildCommand({ cmd: 'zoneColour', lightSegments: [24], value: { r: 0, g: 0, b: 255 } }))
+      .toThrow(/light segment/i)
   })
 
-  it('refuses a negative segment', () => {
-    expect(() => buildCommand({ cmd: 'zoneColour', segments: [-1], value: { r: 0, g: 0, b: 255 } }))
-      .toThrow(/segment/i)
+  it('refuses a negative light segment', () => {
+    expect(() => buildCommand({ cmd: 'zoneColour', lightSegments: [-1], value: { r: 0, g: 0, b: 255 } }))
+      .toThrow(/light segment/i)
   })
 
-  it('refuses a fractional segment', () => {
+  it('refuses a fractional light segment', () => {
     // Without this check `1 << 1.5` is 2 in JS - a fractional index would
     // silently set the neighboring bit instead of failing
-    expect(() => buildCommand({ cmd: 'zoneColour', segments: [1.5], value: { r: 0, g: 0, b: 255 } }))
-      .toThrow(/segment/i)
+    expect(() => buildCommand({ cmd: 'zoneColour', lightSegments: [1.5], value: { r: 0, g: 0, b: 255 } }))
+      .toThrow(/light segment/i)
   })
 
-  it('refuses to build without a value or segments', () => {
-    expect(() => buildCommand({ cmd: 'zoneColour', segments: [0] }))
-      .toThrow(/value|segments/i)
+  it('refuses to build without a value or light segments', () => {
+    expect(() => buildCommand({ cmd: 'zoneColour', lightSegments: [0] }))
+      .toThrow(/value|light segments/i)
     expect(() => buildCommand({ cmd: 'zoneColour', value: { r: 0, g: 0, b: 0 } }))
-      .toThrow(/value|segments/i)
+      .toThrow(/value|light segments/i)
   })
 
-  it('refuses an empty list of segments', () => {
-    // Same failure mode as an out-of-range segment: a valid, fully-inert frame
+  it('refuses an empty list of light segments', () => {
+    // Same failure mode as an out-of-range light segment: a valid, fully-inert frame
     // that quietly does nothing
-    expect(() => buildCommand({ cmd: 'zoneColour', segments: [], value: { r: 0, g: 0, b: 255 } }))
-      .toThrow(/segment/i)
+    expect(() => buildCommand({ cmd: 'zoneColour', lightSegments: [], value: { r: 0, g: 0, b: 255 } }))
+      .toThrow(/light segment/i)
   })
 })
 
@@ -406,7 +406,7 @@ describe('setting a zone\'s color', () => {
     // r/g/b are deliberately distinct (not the palindromic 0/255/0 the plan first
     // used) so a byte-order slip - r and b swapped - fails this test instead of
     // passing unnoticed
-    const { awsParams } = buildCommand({ cmd: 'zoneColour', segments: [16], value: { r: 1, g: 2, b: 3 } })
+    const { awsParams } = buildCommand({ cmd: 'zoneColour', lightSegments: [16], value: { r: 1, g: 2, b: 3 } })
     const hex = Buffer.from(awsParams.data.command[0], 'base64').toString('hex')
 
     expect(hex.slice(0, 8)).toBe('33051501')
@@ -417,7 +417,7 @@ describe('setting a zone\'s color', () => {
   it('goes over aws only', () => {
     // This model ignores ptReal over LAN, and LAN is fire-and-forget - offering
     // it there would count as sent and the command would never arrive (#1333)
-    const result = buildCommand({ cmd: 'zoneColour', segments: [16], value: { r: 255, g: 0, b: 0 } })
+    const result = buildCommand({ cmd: 'zoneColour', lightSegments: [16], value: { r: 255, g: 0, b: 0 } })
 
     expect(result.awsParams.cmd).toBe('ptReal')
     expect(result.lanParams).toBeUndefined()
@@ -431,7 +431,7 @@ describe('setting a zone\'s brightness', () => {
     // Brightness is 33 05 15 02 <level> <mask>, so the mask sits at bytes 5-7.
     // The color frame pads and puts it at 12-14. Sending brightness in the
     // color layout does nothing at all - the light simply ignores it
-    const { awsParams } = buildCommand({ cmd: 'zoneBrightness', segments: [16], value: 70 })
+    const { awsParams } = buildCommand({ cmd: 'zoneBrightness', lightSegments: [16], value: 70 })
     const hex = Buffer.from(awsParams.data.command[0], 'base64').toString('hex')
 
     expect(hex.slice(0, 8)).toBe('33051502')
@@ -440,7 +440,7 @@ describe('setting a zone\'s brightness', () => {
   })
 
   it('takes homekit\'s 0-100 without scaling', () => {
-    const { awsParams } = buildCommand({ cmd: 'zoneBrightness', segments: [0], value: 100 })
+    const { awsParams } = buildCommand({ cmd: 'zoneBrightness', lightSegments: [0], value: 100 })
     const hex = Buffer.from(awsParams.data.command[0], 'base64').toString('hex')
 
     expect(hex.slice(8, 10)).toBe('64')
@@ -449,14 +449,14 @@ describe('setting a zone\'s brightness', () => {
   it('accepts a brightness of 0, which is falsy but valid', () => {
     // A naive `!params.value` guard would reject this - 0 is a real target,
     // not a missing one
-    const { awsParams } = buildCommand({ cmd: 'zoneBrightness', segments: [0], value: 0 })
+    const { awsParams } = buildCommand({ cmd: 'zoneBrightness', lightSegments: [0], value: 0 })
     const hex = Buffer.from(awsParams.data.command[0], 'base64').toString('hex')
 
     expect(hex.slice(8, 10)).toBe('00')
   })
 
   it('goes over aws only', () => {
-    const result = buildCommand({ cmd: 'zoneBrightness', segments: [16], value: 30 })
+    const result = buildCommand({ cmd: 'zoneBrightness', lightSegments: [16], value: 30 })
 
     expect(result.awsParams.cmd).toBe('ptReal')
     expect(result.lanParams).toBeUndefined()
@@ -464,21 +464,21 @@ describe('setting a zone\'s brightness', () => {
     expect(result.bleParams).toBeUndefined()
   })
 
-  it('refuses to build without a value or segments', () => {
-    expect(() => buildCommand({ cmd: 'zoneBrightness', segments: [0] }))
-      .toThrow(/value|segments/i)
+  it('refuses to build without a value or light segments', () => {
+    expect(() => buildCommand({ cmd: 'zoneBrightness', lightSegments: [0] }))
+      .toThrow(/value|light segments/i)
     expect(() => buildCommand({ cmd: 'zoneBrightness', value: 50 }))
-      .toThrow(/value|segments/i)
+      .toThrow(/value|light segments/i)
   })
 
   it('refuses a brightness outside 0-100', () => {
     // Out of range the byte silently wraps instead of throwing - 300 becomes
     // 44 in the frame, and the checksum still comes out clean
-    expect(() => buildCommand({ cmd: 'zoneBrightness', segments: [0], value: 300 }))
+    expect(() => buildCommand({ cmd: 'zoneBrightness', lightSegments: [0], value: 300 }))
       .toThrow(/brightness/i)
-    expect(() => buildCommand({ cmd: 'zoneBrightness', segments: [0], value: -1 }))
+    expect(() => buildCommand({ cmd: 'zoneBrightness', lightSegments: [0], value: -1 }))
       .toThrow(/brightness/i)
-    expect(() => buildCommand({ cmd: 'zoneBrightness', segments: [0], value: 50.5 }))
+    expect(() => buildCommand({ cmd: 'zoneBrightness', lightSegments: [0], value: 50.5 }))
       .toThrow(/brightness/i)
   })
 })

--- a/lib/utils/command-builder.test.js
+++ b/lib/utils/command-builder.test.js
@@ -345,3 +345,58 @@ describe('what goes out for a light zone', () => {
       .toThrow(/zone/i)
   })
 })
+
+describe('addressing a zone by its segments', () => {
+  const maskBytes = hex => hex.slice(24, 30)
+
+  it('puts the background ring in the first two mask bytes', () => {
+    const ring = Array.from({ length: 16 }, (_, index) => index)
+    const { awsParams } = buildCommand({ cmd: 'zoneColour', segments: ring, value: { r: 255, g: 0, b: 0 } })
+    const hex = Buffer.from(awsParams.data.command[0], 'base64').toString('hex')
+
+    expect(maskBytes(hex)).toBe('ffff00')
+  })
+
+  it('puts a seventeenth segment in the third mask byte, which two bytes cannot reach', () => {
+    // The whole reason the main panel was unreachable: segment 16's bit lives
+    // past the two-byte mask every other model in the plugin uses
+    const { awsParams } = buildCommand({ cmd: 'zoneColour', segments: [16], value: { r: 0, g: 0, b: 255 } })
+    const hex = Buffer.from(awsParams.data.command[0], 'base64').toString('hex')
+
+    expect(maskBytes(hex)).toBe('000001')
+  })
+
+  it('refuses a segment it cannot fit in the three-byte mask', () => {
+    // A segment past 23 would silently grow the mask to a fourth byte, which
+    // still checksums cleanly - a wrong frame the device accepts is far harder
+    // to spot than an outright failure
+    expect(() => buildCommand({ cmd: 'zoneColour', segments: [24], value: { r: 0, g: 0, b: 255 } }))
+      .toThrow(/segment/i)
+  })
+
+  it('refuses a negative segment', () => {
+    expect(() => buildCommand({ cmd: 'zoneColour', segments: [-1], value: { r: 0, g: 0, b: 255 } }))
+      .toThrow(/segment/i)
+  })
+
+  it('refuses a fractional segment', () => {
+    // Without this check `1 << 1.5` is 2 in JS - a fractional index would
+    // silently set the neighboring bit instead of failing
+    expect(() => buildCommand({ cmd: 'zoneColour', segments: [1.5], value: { r: 0, g: 0, b: 255 } }))
+      .toThrow(/segment/i)
+  })
+
+  it('refuses to build without a value or segments', () => {
+    expect(() => buildCommand({ cmd: 'zoneColour', segments: [0] }))
+      .toThrow(/value|segments/i)
+    expect(() => buildCommand({ cmd: 'zoneColour', value: { r: 0, g: 0, b: 0 } }))
+      .toThrow(/value|segments/i)
+  })
+
+  it('refuses an empty list of segments', () => {
+    // Same failure mode as an out-of-range segment: a valid, fully-inert frame
+    // that quietly does nothing
+    expect(() => buildCommand({ cmd: 'zoneColour', segments: [], value: { r: 0, g: 0, b: 255 } }))
+      .toThrow(/segment/i)
+  })
+})

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -727,11 +727,14 @@ export default {
   // The H1270 is deliberately absent. It advertises the same capabilities, but
   // nobody has confirmed it shares the fault, so it stays on the toggle path.
   /**
-   * Which segments make up each zone of a two-zone light.
+   * Which light segments make up each zone of a two-zone light. Called "light
+   * segments" to avoid any confusion with the unrelated `segmented`/
+   * `segmentedTwo`/`segmentedThree`/`segmentedFour` config options above,
+   * which name a captured scene or BLE code.
    *
-   * How many segments a light has can be read back from its own report, but
-   * which segments belong to which zone cannot - nothing in the frame says so.
-   * The H1250's split was established by changing one zone at a time and
+   * How many light segments a light has can be read back from its own report,
+   * but which segments belong to which zone cannot - nothing in the frame says
+   * so. The H1250's split was established by changing one zone at a time and
    * watching which segments moved, so this is configuration, and a new model
    * should be measured rather than assumed to share the layout (#1333).
    */

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -726,7 +726,21 @@ export default {
   //
   // The H1270 is deliberately absent. It advertises the same capabilities, but
   // nobody has confirmed it shares the fault, so it stays on the toggle path.
-  zoneLightModels: ['H1250'],
+  /**
+   * Which segments make up each zone of a two-zone light.
+   *
+   * How many segments a light has can be read back from its own report, but
+   * which segments belong to which zone cannot - nothing in the frame says so.
+   * The H1250's split was established by changing one zone at a time and
+   * watching which segments moved, so this is configuration, and a new model
+   * should be measured rather than assumed to share the layout (#1333).
+   */
+  zoneLightModels: {
+    H1250: {
+      main: [16],
+      background: Array.from({ length: 16 }, (_, index) => index),
+    },
+  },
 
   matterModels: [
     'H1401',

--- a/lib/utils/dispatch.js
+++ b/lib/utils/dispatch.js
@@ -23,12 +23,19 @@ import platformConsts from './constants.js'
  *              out still gets power rather than being left unsupported
  * - `choose`   for the few lists where the answer depends on the device or the
  *              owner's settings
- * - `awsPolling` these devices need their status asking for over AWS
+ * - `awsPolling` these devices need their status asking for over AWS. Either a
+ *   boolean for every model in the list, or a function of the same args as
+ *   `choose`, for a list where only some models need it.
  */
 const routes = [
   {
     list: 'rgb',
     choose: ({ deviceConf }) => (deviceConf.showAs === 'switch' ? 'deviceLightSwitch' : 'deviceLight'),
+    // A light segment layout means this model's zone data only ever arrives
+    // in reply to a full AWS status request - LAN never carries it. Every
+    // other light gets everything it needs from LAN polling, so only these
+    // need the extra AWS traffic
+    awsPolling: ({ device }) => Boolean(platformConsts.zoneLightModels[device.model]),
   },
   { list: 'switchSingle', choose: chooseSingleSwitch },
   {
@@ -149,11 +156,15 @@ export function resolveDeviceType(device, deviceConf = {}, cachedContext = undef
     return { skip: chosen.skip, list: route.list }
   }
 
+  const awsPolling = typeof route.awsPolling === 'function'
+    ? route.awsPolling({ device, deviceConf, cachedContext })
+    : !!route.awsPolling
+
   return {
     list: route.list,
     handlerKey: chosen.handler,
     handler: deviceTypes[chosen.handler],
-    awsPolling: !!route.awsPolling,
+    awsPolling,
     externalCategory: chosen.externalCategory,
   }
 }

--- a/lib/utils/dispatch.test.js
+++ b/lib/utils/dispatch.test.js
@@ -121,6 +121,14 @@ describe('which devices need their status asking for', () => {
   it.each(['H6102', 'H5080', 'H5075'])('does not poll the %s', (model) => {
     expect(resolveDeviceType(single(model), {}).awsPolling).toBe(false)
   })
+
+  it('polls a light with a light segment layout, since its zone data only ever arrives over AWS', () => {
+    expect(resolveDeviceType(single('H1250'), {}).awsPolling).toBe(true)
+  })
+
+  it('does not poll a light with no light segment layout', () => {
+    expect(resolveDeviceType(single('H6102'), {}).awsPolling).toBe(false)
+  })
 })
 
 describe('a model of a known type that nobody has worked out', () => {

--- a/test/harness.js
+++ b/test/harness.js
@@ -71,6 +71,12 @@ function defaultValueFor(name) {
 class FakeService {
   constructor(type, name, subtype) {
     this.type = type
+    // Real HAP has no `.type` field - accessory lookups actually match on the
+    // service's UUID/constructor. `.type` above is kept only because so much
+    // of this suite already asserts against it as a readable stand-in for
+    // that; `hapType` is the separate field lookups match against, so a test
+    // can delete `.type` to see what code looks like against a real Service
+    this.hapType = type
     this.displayName = name
     this.subtype = subtype
     this.characteristics = new Map()
@@ -137,8 +143,18 @@ class FakeAccessory {
    * from a previous setting. Matching only the type would silently skip that.
    */
   getService(nameOrType) {
-    return this.services.find(service => service.type === nameOrType)
+    return this.services.find(service => service.hapType === nameOrType)
       || this.services.find(service => service.displayName === nameOrType)
+  }
+
+  /**
+   * Real HAP looks a service up this way by its type and subtype together,
+   * which is what distinguishes two services of the same type (e.g. two
+   * Lightbulbs) on one accessory. `getService` alone cannot do that - it only
+   * matches by type OR by display name.
+   */
+  getServiceById(type, subtype) {
+    return this.services.find(service => service.hapType === type && service.subtype === subtype)
   }
 
   addService(type, name, subtype) {


### PR DESCRIPTION
## :recycle: Current situation

The H1250 Ceiling Light Pro has two independently-addressable zones - a main
downlight panel and a background ring - and #1343 (merged, unreleased) gave
each zone its own on/off tile. But the light can do far more than on/off: in
the Govee app each zone takes its own color and its own brightness. HomeKit
currently has no way to express that, because the zone tiles are `Switch`
services, which only carry `On`.

Two things were blocking this:

1. A `Switch` service can't carry `Brightness`/`Hue`/`Saturation` - the tiles
   need to become `Lightbulb` services.
2. Nobody knew how to address a zone's color or brightness. The OpenAPI
   segment capabilities (`segmentedColorRgb`/`segmentedBrightness`) only ever
   reach the background ring (segments 0-15, capped by Govee's own declared
   range) - the main panel (segment 16) has never been reachable through
   them, and no raw frame was known.

## :bulb: Proposed solution

Reverse-engineered the raw AWS frame for both zones' color and brightness
against real hardware (see Testing for the full acceptance run), and extended
the existing zone mechanism from #1343 rather than adding a parallel path:

- Zone tiles become `Lightbulb` services, carrying `Brightness`, `Hue`,
  `Saturation`, and (unless color-safe mode is on) `ColorTemperature` with its
  own `AdaptiveLightingController` - every tile on the accessory, master and
  both zones, can independently run adaptive lighting.
- `command-builder.js` gains `zoneBrightness` and `zoneColour` cases, built
  from a shared `lightSegmentMask()` helper that turns a model's segment list
  into the frame's 3-byte mask. AWS-only, same transport reasoning as #1343
  (this device silently drops raw frames sent over LAN).
- `constants.js`'s `zoneLightModels` becomes a per-model segment-layout map
  (`{ H1250: { main: [16], background: [0..15] } }`) instead of a bare model
  list, so a future two-zone model only needs a config entry, not new logic.
- `externalUpdate` gains a reader for the `aa a5` segment report, so a zone
  changed from the Govee app, a remote, or the wall reaches the tiles - not
  just this plugin's own writes echoing back.

Two supporting fixes the feature needs to actually work correctly, both found
through live hardware testing:

- Light models were never on the periodic AWS poll list (every other light
  gets what it needs from LAN, so nothing needed this before) - zone tiles
  got one snapshot at Homebridge startup and never refreshed again.
  `dispatch.js`'s `awsPolling` can now be a per-device predicate; the `rgb`
  route polls a model only when it has a light-segment layout.
- A zone's own adaptive lighting compared raw mired, which drifts by a
  fractional amount on almost every adaptive lighting tick, instead of kelvin
  rounded to the nearest 100 like the main light already does - so it sent a
  real command to the device roughly once a minute instead of only when the
  color meaningfully changed.

## :gear: Release Notes

The H1250's main panel and background ring can now be colored and dimmed
independently from HomeKit, with adaptive lighting available on the master
tile and on each zone separately. No configuration changes needed - existing
zone on/off tiles upgrade in place.

Known characteristic, not a bug: a zone color or brightness change made
outside HomeKit (Govee app, a remote, or at the wall) can take up to about a
minute to reach the zone tiles, because this device only ever reports its
zone state in reply to a full status request, never over LAN.

## :heavy_plus_sign: Additional Information

### Hardware findings

Everything below was verified against real hardware (H1250, firmware
1.01.31) by sending a frame and reading the light's own report back, not by
judging by eye.

The device has 17 addressable segments, reported in `aa a5 <page>` frames (5
pages, 4 segments per page): segments 0-15 are the background ring, segment
16 is the main panel - established by changing one zone at a time in the
Govee app and watching which segments moved.

```
on/off      33 30 <zone> <state>                                  zone 00 = main, 01 = ring
color       33 05 15 01 <r> <g> <b> 00 00 00 00 00 <m0> <m1> <m2>  mask at bytes 12-14
brightness  33 05 15 02 <level> <m0> <m1> <m2>                     mask at bytes 5-7
```

The mask is a 3-byte, little-endian, one-bit-per-segment field: `ff ff 00`
addresses the ring, `00 00 01` addresses the main panel. The color frame
isn't new - it's `COLOR_SUB.RGB_EXTENDED` with a suffix already used for the
H6053/H6072/H6199, just with a 3-byte mask where those models use 2, which is
exactly why nothing ever reached segment 16 before. Brightness's mask sits at
a different byte offset than color's; assuming they matched is what made
several early attempts fail.

The OpenAPI segment capabilities genuinely cannot reach segment 16
(`{"errorCode":400,"errorMsg":"Parameter value out of range"}` for both
`segmentedColorRgb` and `segmentedBrightness`) - Govee's own declared range
caps at 15. `33 a5 <page>` (the naive mirror of `aa a5`) does nothing at all.
`33 04 <level> …<mask>` dims the whole light and ignores the mask, confirming
it as the pre-existing device-wide opcode, not a zone-specific one.

### Testing

Unit tests added across `command-builder.test.js`, `dispatch.test.js`, and
`light-zones.test.js`: frame and mask construction for both controls
including the two different mask offsets, per-model segment layout, the
Lightbulb conversion and its migration from the old Switch tiles, the
brightness/color/color-temperature handlers and their debounce, adaptive
lighting attach/detach and its interaction with an externally-changed zone,
segment-report decoding including the padding on the last page, and the
periodic AWS-polling predicate.

Hardware verification: a five-check acceptance run against the real device,
each asserting the exact segment set that moved *and* the exact value it
took, plus that the other zone held its own value:

| check | result |
| --- | --- |
| ring color → `#00ff00` | segments 0-15 moved, all read `00ff00` |
| main color → `#ff0000`, ring holds | segment 16 only, ring still `00ff00` |
| ring brightness → 20 | segments 0-15, all read 20 |
| main brightness → 40, ring holds 20 | segment 16 only |
| ring brightness → 60, main holds 40 | segments 0-15 only |

Also confirmed live through the running plugin, not just the frame layer:
adaptive lighting working independently on a single zone and on the whole
light at once, with no cross-zone contamination when one zone's color
changes; brightness and color debounce matching the main light's existing
behavior under a rapid slider drag; a zone set to 0% brightness turning off
cleanly in HomeKit; the whole light restoring each zone's prior state after
an off/on cycle; and external changes made from the Govee app reaching the
zone tiles correctly.

### Out of scope

- BLE. The Govee app drives zones over Bluetooth, but AWS reaches every
  control needed, so there's no reason to open that up here.
- Individual segment control. The light exposes 17 addressable segments;
  exposing anything finer than the two zones is a separate feature.
- The `describeControlFailure` gap from #1343, where Govee reports success
  for a command it never delivers. Still real, still a separate PR.
- The interaction between the main light's adaptive lighting and
  independently-set zone colors. Confirmed on hardware: if the master's
  adaptive lighting is left on after a zone's color is set directly, it will
  eventually overwrite that zone's color the next time it sends a real
  update, because the master has no way to know a zone changed underneath
  it. Not touched here per your note that adaptive lighting behavior is
  worth its own issue rather than folded into the zone work - happy to open
  one with these details if useful.

### Reviewer Nudging

`lib/utils/command-builder.js`'s `lightSegmentMask()` and the two new
`build*Command` functions are the core of the new protocol and the smallest
self-contained place to start. From there, `lib/device/light.js`'s zone tile
creation loop (where `Lightbulb` replaces `Switch`) and `externalUpdate`'s
segment reader are where most of the actual behavior lives.
