### PR TITLE
fix: stop rescaling the H1250's brightness, since it already counts to 100 over AWS

### DIFF
--- a/lib/utils/command-builder.test.js
+++ b/lib/utils/command-builder.test.js
@@ -118,6 +118,9 @@ describe('what goes out over AWS', () => {
     // between two brightnesses (#1321)
     expect(buildCommand({ cmd: 'brightness', value: 50 }, { gvModel: 'H6008' }).awsParams.data.val).toBe(50)
     expect(buildCommand({ cmd: 'brightness', value: 50 }, { gvModel: 'H6102', awsBrightnessNoScale: true }).awsParams.data.val).toBe(50)
+    // H1250: scaling sent a 100% HomeKit write out as 254, and the device came
+    // out visibly dimmer than the Govee app's own 100% - confirmed on hardware
+    expect(buildCommand({ cmd: 'brightness', value: 100 }, { gvModel: 'H1250' }).awsParams.data.val).toBe(100)
   })
 
   it('uses the odd on and off values the plugs need', () => {

--- a/lib/utils/device-capabilities.js
+++ b/lib/utils/device-capabilities.js
@@ -80,6 +80,12 @@ const modelOverrides = {
   H1401: { awsBrightnessNoScale: true },
   H6008: { awsBrightnessNoScale: true },
   H6022: { awsBrightnessNoScale: true },
+
+  // H1250: proven live on hardware 2026-08-08 - a HomeKit write of 100 sent
+  // val:254 and came out visibly dimmer than the Govee app's own 100%, then the
+  // AWS echo of {"brightness":100} was rescaled down to 39%, matching every
+  // step of a slider drag exactly (98->39, 69->27, 42->17, 97->38, 43->17)
+  H1250: { awsBrightnessNoScale: true },
 }
 
 /**


### PR DESCRIPTION
## :recycle: Current situation

The H1250 Ceiling Light Pro already reports and expects brightness as a 0-100
value over AWS - the same scale HomeKit uses - but it has no entry in
`device-capabilities.js`'s `awsBrightnessNoScale` list, so the plugin applies
the standard AWS 0-254 scaling meant for devices that need it. Two visible
symptoms follow from that single mismatch:

1. A HomeKit brightness write of 100% sends `val: 254` to a device that only
   understands 0-100, and the light renders visibly dimmer than the Govee
   app's own 100%.
2. The AWS echo of the device's real brightness (already 0-100, e.g.
   `{"brightness":100}`) then gets divided by 2.54 on the way back in, so the
   HomeKit tile silently drifts to a wrong value shortly after every change.

## :bulb: Proposed solution

Add `H1250: { awsBrightnessNoScale: true }` to `device-capabilities.js`'s
`modelOverrides` - the same fix already applied for H1401/H6008/H6022 (#1321).
The shared scaling logic in `command-builder.js` and `response-parser.js`
already branches on this flag correctly; no other code changes needed.

## :gear: Release Notes

Fixes the H1250 Ceiling Light Pro's brightness in HomeKit. It previously came
out dimmer than expected at 100%, and could visibly drift to the wrong value
shortly after being set. No configuration change needed.

## :heavy_plus_sign: Additional Information

### Testing

Confirmed against real hardware: dragging the brightness slider produced a
series of AWS echoes that were each rescaled to roughly 39% of the real value
- every single step matched `value / 2.54` rounded, exactly (100→39, 98→39,
69→27, 42→17, 97→38, 43→17) - and the light visibly rendered dimmer at "100%"
than the Govee app's own 100%. Added a unit test asserting a 100% HomeKit
write now sends `val: 100`, not `254`, to `command-builder.test.js`. Full
suite passes.

### Reviewer Nudging

One hunk in `device-capabilities.js`, directly beneath the existing
H1401/H6008/H6022 entries it mirrors - that's the fastest way to sanity-check
the change matches precedent.
