### PR TITLE
fix(H5054): don't let a slow leak warning block other sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to `@homebridge-plugins/homebridge-govee` will be documented
 - fix: apply the openapi disable and refresh settings instead of asking for them to be removed
 - fix: say once when a bluetooth reading arrives for an unknown device, not on every broadcast
 - fix: reject a refresh time so large it would make the plugin poll every millisecond
+- fix(H5054): don't let a slow leak warning block other sensors
 
 ## v11.34.1 (2026-08-06)
 

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -408,11 +408,7 @@ export default class {
 
       // Set up the http client sync needed for leak and thermo sensor devices
       if (this.httpClient && httpSyncNeeded) {
-        this.goveeHTTPSync()
-        this.refreshHTTPInterval = setInterval(
-          () => this.runPeriodicSync('HTTP', () => this.goveeHTTPSync()),
-          this.config.httpRefreshTime * 1000,
-        )
+        this.setupHTTPSync()
       }
 
       if (this.openApiClient && (openApiDevicesWereInitialised || httpDevicesWereInitialised)) {
@@ -787,6 +783,14 @@ export default class {
     }
   }
 
+  setupHTTPSync() {
+    this.runPeriodicSync('HTTP', () => this.goveeHTTPSync())
+    this.refreshHTTPInterval = setInterval(
+      () => this.runPeriodicSync('HTTP', () => this.goveeHTTPSync()),
+      this.config.httpRefreshTime * 1000,
+    )
+  }
+
   async goveeAWSSync(allDevices = false) {
     const pollList = allDevices ? awsDevices : awsDevicesToPoll
     if (pollList.length === 0) {
@@ -864,123 +868,129 @@ export default class {
       // Obtain a refreshed device list
       const devices = await this.httpClient.getDevices(true)
 
-      // Filter those which are leak sensors
-      for (const device1 of devices
-        .filter(device => [...platformConsts.models.sensorLeak, ...platformConsts.models.sensorThermo, ...platformConsts.models.sensorMonitor].includes(device.sku))) {
-        try {
-          // Reformat the device id
-          if (!device1.device.includes(':')) {
-            // Eg converts abcd1234abcd1234 to AB:CD:12:34:AB:CD:12:34
-            // For sensors with an add-on sensor like H5178
-            // Eg converts abcd1234abcd1234_1 to AB:CD:12:34:AB:CD:12:34_1
-            device1.device = device1.device.replace(DEVICE_ID_FORMAT_REGEX, '$&:').toUpperCase()
-          }
-
-          // Generate the UIID from which we can match our Homebridge accessory
-          const uiid = this.api.hap.uuid.generate(device1.device)
-
-          // Don't continue if the accessory doesn't exist
-          if (!devicesInHB.has(uiid)) {
-            continue
-          }
-
-          // Retrieve the Homebridge accessory
-          const accessory = devicesInHB.get(uiid)
-
-          // Make sure the data we need for the device exists
-          if (!device1.deviceExt || !device1.deviceExt.deviceSettings || !device1.deviceExt.lastDeviceData) {
-            continue
-          }
-
-          // Parse the data received
-          let parsedSettings
-          let parsedData
+      // A stalled leak-warning request must not hold every water sensor behind
+      // it. Queue only those cloud requests so thermometer and monitor updates
+      // still arrive immediately, while a poll stays gentle on Govee's API.
+      const leakWarningQueue = new PQueue({ concurrency: 2 })
+      await Promise.all(devices
+        .filter(device => [...platformConsts.models.sensorLeak, ...platformConsts.models.sensorThermo, ...platformConsts.models.sensorMonitor].includes(device.sku))
+        .map(async (device1) => {
           try {
-            parsedSettings = JSON.parse(device1.deviceExt.deviceSettings)
-            parsedData = JSON.parse(device1.deviceExt.lastDeviceData)
-          } catch {
-            continue
-          }
-
-          const toReturn = { source: 'HTTP' }
-          if (platformConsts.models.sensorLeak.includes(device1.sku)) {
-            accessory.logDebug(`raw data: ${JSON.stringify({ ...parsedData, ...parsedSettings })}`)
-
-            // Keep the gateway details up to date for matching real-time leak
-            // events relayed by the gateway over AWS (#1276)
-            if (hasProperty(parsedSettings, 'sno') && parsedSettings.gatewayInfo?.device) {
-              accessory.context.gatewaySno = parsedSettings.sno
-              accessory.context.gatewayDevice = parsedSettings.gatewayInfo.device
+            // Reformat the device id
+            if (!device1.device.includes(':')) {
+              // Eg converts abcd1234abcd1234 to AB:CD:12:34:AB:CD:12:34
+              // For sensors with an add-on sensor like H5178
+              // Eg converts abcd1234abcd1234_1 to AB:CD:12:34:AB:CD:12:34_1
+              device1.device = device1.device.replace(DEVICE_ID_FORMAT_REGEX, '$&:').toUpperCase()
             }
 
-            // Leak Sensors - check to see of any warnings if the lastTime is above 0
-            let hasUnreadLeak = false
-            if (parsedData.lastTime > 0) {
-              // Obtain the leak warning messages for this device
-              const msgs = await this.httpClient.getLeakDeviceWarning(device1.device, device1.sku)
+            // Generate the UIID from which we can match our Homebridge accessory
+            const uiid = this.api.hap.uuid.generate(device1.device)
 
-              accessory.logDebug(`raw messages: ${JSON.stringify(msgs)}`)
+            // Don't continue if the accessory doesn't exist
+            if (!devicesInHB.has(uiid)) {
+              return
+            }
 
-              // Check to see if unread messages exist
-              const unreadCount = msgs.filter(msg => !msg.read && msg.message.toLowerCase().replace(WHITESPACE_REGEX, '').startsWith('leakagealert'))
-              if (unreadCount.length > 0) {
-                hasUnreadLeak = true
+            // Retrieve the Homebridge accessory
+            const accessory = devicesInHB.get(uiid)
+
+            // Make sure the data we need for the device exists
+            if (!device1.deviceExt || !device1.deviceExt.deviceSettings || !device1.deviceExt.lastDeviceData) {
+              return
+            }
+
+            // Parse the data received
+            let parsedSettings
+            let parsedData
+            try {
+              parsedSettings = JSON.parse(device1.deviceExt.deviceSettings)
+              parsedData = JSON.parse(device1.deviceExt.lastDeviceData)
+            } catch {
+              return
+            }
+
+            const toReturn = { source: 'HTTP' }
+            if (platformConsts.models.sensorLeak.includes(device1.sku)) {
+              accessory.logDebug(`raw data: ${JSON.stringify({ ...parsedData, ...parsedSettings })}`)
+
+              // Keep the gateway details up to date for matching real-time leak
+              // events relayed by the gateway over AWS (#1276)
+              if (hasProperty(parsedSettings, 'sno') && parsedSettings.gatewayInfo?.device) {
+                accessory.context.gatewaySno = parsedSettings.sno
+                accessory.context.gatewayDevice = parsedSettings.gatewayInfo.device
+              }
+
+              // Leak Sensors - check to see of any warnings if the lastTime is above 0
+              let hasUnreadLeak = false
+              if (parsedData.lastTime > 0) {
+                // Obtain the leak warning messages for this device
+                const msgs = await leakWarningQueue.add(
+                  () => this.httpClient.getLeakDeviceWarning(device1.device, device1.sku),
+                )
+
+                accessory.logDebug(`raw messages: ${JSON.stringify(msgs)}`)
+
+                // Check to see if unread messages exist
+                const unreadCount = msgs.filter(msg => !msg.read && msg.message.toLowerCase().replace(WHITESPACE_REGEX, '').startsWith('leakagealert'))
+                if (unreadCount.length > 0) {
+                  hasUnreadLeak = true
+                }
+              }
+
+              // Generate the params to return
+              toReturn.battery = parsedSettings.battery
+              toReturn.leakDetected = hasUnreadLeak
+              toReturn.online = parsedData.gwonline && parsedData.online
+            } else if (platformConsts.models.sensorThermo.includes(device1.sku)) {
+              // Some accounts report `tem` in hundredths of a degree Fahrenheit
+              // rather than Celsius, which lands in HomeKit as a reading roughly
+              // 90 degrees too high (#1269). The unit is not stated anywhere in
+              // the response, so log the raw payload to work out what
+              // distinguishes those accounts before converting anything.
+              accessory.logDebug(`[HTTP] raw sensor data: ${JSON.stringify(parsedData)}`)
+
+              if (hasProperty(parsedSettings, 'battery')) {
+                toReturn.battery = parsedSettings.battery
+              }
+              if (hasProperty(parsedData, 'tem')) {
+                toReturn.temperature = parsedData.tem
+              }
+              if (hasProperty(parsedData, 'hum')) {
+                toReturn.humidity = parsedData.hum
+              }
+              if (hasProperty(parsedData, 'online')) {
+                toReturn.online = parsedData.online
+              }
+            } else if (platformConsts.models.sensorMonitor.includes(device1.sku)) {
+              // The H5106 normally reports over AWS, but some accounts never
+              // receive those messages, leaving the readings at zero (#1322).
+              // The HTTP device list carries the same readings, so use it as a
+              // second source. Every field is guarded and the raw payload is
+              // logged, since the format for this model is not confirmed on
+              // every account
+              accessory.logDebug(`[HTTP] raw sensor data: ${JSON.stringify(parsedData)}`)
+
+              if (hasProperty(parsedSettings, 'battery')) {
+                toReturn.battery = parsedSettings.battery
+              }
+              if (hasProperty(parsedData, 'tem')) {
+                toReturn.temperature = parsedData.tem
+              }
+              if (hasProperty(parsedData, 'hum')) {
+                toReturn.humidity = parsedData.hum
+              }
+              if (hasProperty(parsedData, 'online')) {
+                toReturn.online = parsedData.online
               }
             }
 
-            // Generate the params to return
-            toReturn.battery = parsedSettings.battery
-            toReturn.leakDetected = hasUnreadLeak
-            toReturn.online = parsedData.gwonline && parsedData.online
-          } else if (platformConsts.models.sensorThermo.includes(device1.sku)) {
-            // Some accounts report `tem` in hundredths of a degree Fahrenheit
-            // rather than Celsius, which lands in HomeKit as a reading roughly
-            // 90 degrees too high (#1269). The unit is not stated anywhere in
-            // the response, so log the raw payload to work out what
-            // distinguishes those accounts before converting anything.
-            accessory.logDebug(`[HTTP] raw sensor data: ${JSON.stringify(parsedData)}`)
-
-            if (hasProperty(parsedSettings, 'battery')) {
-              toReturn.battery = parsedSettings.battery
-            }
-            if (hasProperty(parsedData, 'tem')) {
-              toReturn.temperature = parsedData.tem
-            }
-            if (hasProperty(parsedData, 'hum')) {
-              toReturn.humidity = parsedData.hum
-            }
-            if (hasProperty(parsedData, 'online')) {
-              toReturn.online = parsedData.online
-            }
-          } else if (platformConsts.models.sensorMonitor.includes(device1.sku)) {
-            // The H5106 normally reports over AWS, but some accounts never
-            // receive those messages, leaving the readings at zero (#1322).
-            // The HTTP device list carries the same readings, so use it as a
-            // second source. Every field is guarded and the raw payload is
-            // logged, since the format for this model is not confirmed on
-            // every account
-            accessory.logDebug(`[HTTP] raw sensor data: ${JSON.stringify(parsedData)}`)
-
-            if (hasProperty(parsedSettings, 'battery')) {
-              toReturn.battery = parsedSettings.battery
-            }
-            if (hasProperty(parsedData, 'tem')) {
-              toReturn.temperature = parsedData.tem
-            }
-            if (hasProperty(parsedData, 'hum')) {
-              toReturn.humidity = parsedData.hum
-            }
-            if (hasProperty(parsedData, 'online')) {
-              toReturn.online = parsedData.online
-            }
+            // Send the information to the update receiver function
+            this.receiveDeviceUpdate(accessory, toReturn)
+          } catch (err) {
+            this.log.warn('[%s] %s %s.', device1.deviceName, platformLang.devNotRef, parseError(err))
           }
-
-          // Send the information to the update receiver function
-          this.receiveDeviceUpdate(accessory, toReturn)
-        } catch (err) {
-          this.log.warn('[%s] %s %s.', device1.deviceName, platformLang.devNotRef, parseError(err))
-        }
-      }
+        }))
     } catch (err) {
       this.log.warn('[HTTP] %s %s.', platformLang.syncFail, parseError(err))
     }

--- a/test/h5054-timeout.test.js
+++ b/test/h5054-timeout.test.js
@@ -1,0 +1,221 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import GoveePlatform from '../lib/platform.js'
+import { deviceIdFor, makePlatform } from './harness.js'
+
+function sensor(name, model = 'H5054') {
+  return {
+    device: deviceIdFor(model),
+    deviceName: name,
+    model,
+  }
+}
+
+function httpDevice(device, name, lastDeviceData = { gwonline: true, online: true, lastTime: 1 }) {
+  return {
+    device: device.device,
+    deviceName: name,
+    sku: device.model,
+    deviceExt: {
+      deviceSettings: JSON.stringify({ battery: 88 }),
+      lastDeviceData: JSON.stringify(lastDeviceData),
+    },
+  }
+}
+
+function deferred() {
+  let resolve
+  const promise = new Promise((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+describe('h5054 HTTP timeout containment', () => {
+  it('keeps the timed-out sensor untouched and continues to its sibling', async () => {
+    const platform = makePlatform()
+    const instance = new GoveePlatform()
+    Object.assign(instance, platform, { syncsInFlight: new Set() })
+
+    const first = sensor('synthetic-first')
+    const second = sensor('synthetic-second')
+    instance.initialiseDevice(first)
+    instance.initialiseDevice(second)
+    const firstAccessory = platform.accessories.get(instance.api.hap.uuid.generate(first.device))
+    firstAccessory.control.externalUpdate({ leakDetected: true })
+
+    const updates = []
+    let firstWarningRequest = true
+    const receiveDeviceUpdate = instance.receiveDeviceUpdate.bind(instance)
+    instance.receiveDeviceUpdate = (accessory, params) => {
+      updates.push(params)
+      receiveDeviceUpdate(accessory, params)
+    }
+    instance.httpClient = {
+      getDevices: vi.fn(async () => [httpDevice(first, first.deviceName), httpDevice(second, second.deviceName)]),
+      getLeakDeviceWarning: vi.fn(async (id) => {
+        if (id === first.device && firstWarningRequest) {
+          firstWarningRequest = false
+          throw new Error('synthetic timeout')
+        }
+        return []
+      }),
+    }
+
+    await instance.goveeHTTPSync()
+
+    expect(instance.httpClient.getLeakDeviceWarning).toHaveBeenCalledTimes(2)
+    expect(updates).toEqual([{ source: 'HTTP', battery: 88, leakDetected: false, online: true }])
+    expect(firstAccessory.getService('LeakSensor').getCharacteristic('LeakDetected').value).toBe(1)
+    expect(platform.log.entries.filter(entry => entry.level === 'warn')).toHaveLength(1)
+
+    await instance.goveeHTTPSync()
+
+    expect(instance.httpClient.getLeakDeviceWarning).toHaveBeenCalledTimes(4)
+    expect(updates).toHaveLength(3)
+    expect(firstAccessory.getService('LeakSensor').getCharacteristic('LeakDetected').value).toBe(0)
+  })
+
+  it('keeps startup and interval HTTP syncs behind the same overlap guard', async () => {
+    vi.useFakeTimers()
+    const instance = new GoveePlatform()
+    instance.config = { httpRefreshTime: 1 }
+    instance.log = Object.assign(() => {}, { debugWarn: vi.fn() })
+    instance.syncsInFlight = new Set()
+
+    const pending = deferred()
+    instance.goveeHTTPSync = vi.fn(() => pending.promise)
+
+    try {
+      instance.setupHTTPSync()
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(1000)
+
+      expect(instance.goveeHTTPSync).toHaveBeenCalledTimes(1)
+      expect(instance.syncsInFlight.has('HTTP')).toBe(true)
+    } finally {
+      pending.resolve()
+      clearInterval(instance.refreshHTTPInterval)
+      vi.useRealTimers()
+    }
+  })
+
+  it('starts a healthy sibling and then the third leak check while the first remains stalled', async () => {
+    const platform = makePlatform()
+    const instance = new GoveePlatform()
+    Object.assign(instance, platform, { syncsInFlight: new Set() })
+
+    const first = sensor('synthetic-stalled')
+    const second = sensor('synthetic-healthy')
+    const third = sensor('synthetic-queued')
+    instance.initialiseDevice(first)
+    instance.initialiseDevice(second)
+    instance.initialiseDevice(third)
+
+    const firstWarning = deferred()
+    const secondWarning = deferred()
+    const secondStarted = deferred()
+    const thirdStarted = deferred()
+    let activeWarnings = 0
+    let maxActiveWarnings = 0
+    const getLeakDeviceWarning = vi.fn((id) => {
+      activeWarnings += 1
+      maxActiveWarnings = Math.max(maxActiveWarnings, activeWarnings)
+      if (id === first.device) {
+        return firstWarning.promise.finally(() => {
+          activeWarnings -= 1
+        })
+      }
+      if (id === second.device) {
+        secondStarted.resolve()
+        return secondWarning.promise.finally(() => {
+          activeWarnings -= 1
+        })
+      }
+      thirdStarted.resolve()
+      activeWarnings -= 1
+      return []
+    })
+    instance.httpClient = {
+      getDevices: vi.fn(async () => [
+        httpDevice(first, first.deviceName),
+        httpDevice(second, second.deviceName),
+        httpDevice(third, third.deviceName),
+      ]),
+      getLeakDeviceWarning,
+    }
+
+    const sync = instance.goveeHTTPSync()
+    await secondStarted.promise
+    expect(getLeakDeviceWarning).toHaveBeenCalledTimes(2)
+    expect(activeWarnings).toBe(2)
+    expect(maxActiveWarnings).toBe(2)
+
+    secondWarning.resolve([])
+    await thirdStarted.promise
+    expect(getLeakDeviceWarning).toHaveBeenCalledTimes(3)
+    expect(activeWarnings).toBe(1)
+    expect(maxActiveWarnings).toBe(2)
+
+    firstWarning.resolve([])
+    await sync
+  })
+
+  it('updates an H5106 monitor while two leak-warning calls remain pending', async () => {
+    const platform = makePlatform()
+    const instance = new GoveePlatform()
+    Object.assign(instance, platform, { syncsInFlight: new Set() })
+
+    const first = sensor('synthetic-stalled-first')
+    const second = sensor('synthetic-stalled-second')
+    const monitor = sensor('synthetic-monitor', 'H5106')
+    instance.initialiseDevice(first)
+    instance.initialiseDevice(second)
+    instance.initialiseDevice(monitor)
+
+    const firstWarning = deferred()
+    const secondWarning = deferred()
+    const firstStarted = deferred()
+    const secondStarted = deferred()
+    const monitorUpdated = deferred()
+    let activeWarnings = 0
+    instance.receiveDeviceUpdate = vi.fn((accessory, params) => {
+      if (accessory.UUID === instance.api.hap.uuid.generate(monitor.device)) {
+        monitorUpdated.resolve(params)
+      }
+    })
+    instance.httpClient = {
+      getDevices: vi.fn(async () => [
+        httpDevice(first, first.deviceName),
+        httpDevice(second, second.deviceName),
+        httpDevice(monitor, monitor.deviceName, { online: true, tem: 2150, hum: 4530 }),
+      ]),
+      getLeakDeviceWarning: vi.fn((id) => {
+        activeWarnings += 1
+        if (id === first.device) {
+          firstStarted.resolve()
+          return firstWarning.promise.finally(() => {
+            activeWarnings -= 1
+          })
+        }
+        secondStarted.resolve()
+        return secondWarning.promise.finally(() => {
+          activeWarnings -= 1
+        })
+      }),
+    }
+
+    const sync = instance.goveeHTTPSync()
+    const [, , monitorParams] = await Promise.all([
+      firstStarted.promise,
+      secondStarted.promise,
+      monitorUpdated.promise,
+    ])
+    expect(activeWarnings).toBe(2)
+    expect(monitorParams).toEqual({ source: 'HTTP', battery: 88, temperature: 2150, humidity: 4530, online: true })
+
+    firstWarning.resolve([])
+    secondWarning.resolve([])
+    await sync
+  })
+})


### PR DESCRIPTION
## Summary

H5054 leak sensors fire a separate Govee HTTP request for warning messages on each poll. Those requests used to run one after another, so a single 10-second timeout held up every leak sensor after it — even when their own requests were fine.

I ran into this yesterday with two H5054 sensors in my own setup. Homebridge stayed up, but the timeout from one sensor needlessly held up the other one.

That timeout path was already safe: the sensor keeps its current HomeKit leak state and picks up again on the next poll. Nothing here changes that. The problem was only the extra wait forced on healthy siblings.

Leak-warning requests now go through a local queue with concurrency 2. Nothing else uses that queue, so H5106 and other HTTP sensor updates aren't stuck behind it.

Startup HTTP sync now also enters the existing overlap guard used by interval polling. Before this change, startup bypassed that guard; routing both paths through it prevents the initial sync and the first interval from overlapping. No retries, config changes, or dependency bumps.

## Testing

Without the fix, the regression fails because the second leak-warning request never starts while the first is held. The focused tests cover:

- timed-out sensor keeps prior leak state and recovers on a later poll
- startup and interval polling don't overlap
- healthy sibling completes while the first request is held, and a third waits for a free slot
- H5106 updates still go through while two leak-warning requests are held

Rebased full suite: 470 tests on Node 22, 24, and 26. Lint, changelog sync, and `git diff --check` are clean. Restoring each of the three old behaviors with a mutation makes the matching regression fail again.

Sanitized retained logs showed six H5054 timeouts across two sensors, including a pair of different sensors timing out 10 seconds apart. In an approved live test, the first warning-request slot was deliberately held for 11 seconds and the second finished right away; Homebridge stayed healthy, and the temporary probe was removed. No natural Govee timeout showed up during the patched live window.

Fixtures are synthetic — no real device data.
