### PR TITLE
fix: mark sensor batteries low at the configured threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ All notable changes to `@homebridge-plugins/homebridge-govee` will be documented
 - fix: apply the openapi disable and refresh settings instead of asking for them to be removed
 - fix: say once when a bluetooth reading arrives for an unknown device, not on every broadcast
 - fix: reject a refresh time so large it would make the plugin poll every millisecond
-- fix(H5054): don't let a slow leak warning block other sensors
+- fix(H5054): don't let a slow leak warning block other sensors (#1348)
+- fix: mark sensor batteries low at the configured threshold
 
 ## v11.34.1 (2026-08-06)
 

--- a/lib/device/base.js
+++ b/lib/device/base.js
@@ -53,6 +53,27 @@ export default class GoveeDevice {
     return !!existing
   }
 
+  updateBattery(battery) {
+    if (!this.battService || !Number.isFinite(battery) || battery < 0 || battery > 100) {
+      return
+    }
+
+    if (battery !== this.cacheBatt) {
+      this.cacheBatt = battery
+      this.battService.updateCharacteristic(this.hapChar.BatteryLevel, this.cacheBatt)
+      this.accessory.log(`${platformLang.curBatt} [${this.cacheBatt}%]`)
+    }
+
+    const lowBattery = battery <= this.lowBattThreshold ? 1 : 0
+    const currentLowBattery = Number(this.battService
+      .getCharacteristic(this.hapChar.StatusLowBattery)
+      .value)
+
+    if (lowBattery !== currentLowBattery) {
+      this.battService.updateCharacteristic(this.hapChar.StatusLowBattery, lowBattery)
+    }
+  }
+
   /**
    * Give up on a control, put it back the way it was, and tell HomeKit.
    *

--- a/lib/device/sensor-leak.js
+++ b/lib/device/sensor-leak.js
@@ -47,19 +47,7 @@ export default class extends GoveeDevice {
       this.platform.updateAccessoryStatus(this.accessory, this.cacheOnline)
     }
 
-    // Check to see if the provided battery is different from the cached state
-    if (Number.isFinite(params.battery) && params.battery !== this.cacheBatt) {
-      // Battery is different so update Homebridge with new values
-      this.cacheBatt = params.battery
-      this.battService.updateCharacteristic(this.hapChar.BatteryLevel, this.cacheBatt)
-      this.battService.updateCharacteristic(
-        this.hapChar.StatusLowBattery,
-        this.cacheBatt < this.lowBattThreshold ? 1 : 0,
-      )
-
-      // Log the change
-      this.accessory.log(`${platformLang.curBatt} [${this.cacheBatt}%]`)
-    }
+    this.updateBattery(params.battery)
 
     // Check to see if the provided leak status is different from the cached state
     if (hasProperty(params, 'leakDetected') && params.leakDetected !== this.cacheLeak) {

--- a/lib/device/sensor-thermo-switch.js
+++ b/lib/device/sensor-thermo-switch.js
@@ -104,19 +104,7 @@ export default class extends GoveeDevice {
       return
     }
 
-    // Check to see if the provided battery is different from the cached state
-    if (Number.isFinite(params.battery) && params.battery !== this.cacheBatt && this.battService) {
-      // Battery is different so update Homebridge with new values
-      this.cacheBatt = params.battery
-      this.battService.updateCharacteristic(this.hapChar.BatteryLevel, this.cacheBatt)
-      this.battService.updateCharacteristic(
-        this.hapChar.StatusLowBattery,
-        this.cacheBatt < this.lowBattThreshold ? 1 : 0,
-      )
-
-      // Log the change
-      this.accessory.log(`${platformLang.curBatt} [${this.cacheBatt}%]`)
-    }
+    this.updateBattery(params.battery)
 
     // Check to see if the provided temperature is different from the cached state
     if (hasProperty(params, 'temperature')) {

--- a/lib/device/sensor-thermo.js
+++ b/lib/device/sensor-thermo.js
@@ -80,19 +80,7 @@ export default class extends GoveeDevice {
       return
     }
 
-    // Check to see if the provided battery is different from the cached state
-    if (Number.isFinite(params.battery) && params.battery !== this.cacheBatt && this.battService) {
-      // Battery is different so update Homebridge with new values
-      this.cacheBatt = params.battery
-      this.battService.updateCharacteristic(this.hapChar.BatteryLevel, this.cacheBatt)
-      this.battService.updateCharacteristic(
-        this.hapChar.StatusLowBattery,
-        this.cacheBatt < this.lowBattThreshold ? 1 : 0,
-      )
-
-      // Log the change
-      this.accessory.log(`${platformLang.curBatt} [${this.cacheBatt}%]`)
-    }
+    this.updateBattery(params.battery)
 
     // Check to see if the provided temperature is different from the cached state
     if (hasProperty(params, 'temperature')) {

--- a/test/battery-status.test.js
+++ b/test/battery-status.test.js
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import SensorLeak from '../lib/device/sensor-leak.js'
+import SensorThermoSwitch from '../lib/device/sensor-thermo-switch.js'
+import SensorThermo from '../lib/device/sensor-thermo.js'
+import { makeAccessory, makePlatform } from './harness.js'
+
+const handlers = [
+  ['leak sensor', SensorLeak],
+  ['thermo sensor', SensorThermo],
+  ['thermo switch sensor', SensorThermoSwitch],
+]
+
+function buildDevice(DeviceClass, {
+  battery = 50,
+  low = 0,
+  seedBattery = true,
+  threshold = 20,
+} = {}) {
+  const platform = makePlatform({
+    config: { bleRefreshTime: 30, disableDeviceLogging: false },
+  })
+  const accessory = makeAccessory('SYNTHETIC', { offHumi: 0, offTemp: 0 })
+  platform.deviceConf[accessory.context.gvDeviceId] = { lowBattThreshold: threshold }
+
+  const device = new DeviceClass(platform, accessory)
+  if (seedBattery) {
+    device.cacheBatt = battery
+    device.battService.updateCharacteristic(device.hapChar.BatteryLevel, battery)
+    device.battService.updateCharacteristic(device.hapChar.StatusLowBattery, low)
+  }
+  accessory.log.calls.length = 0
+  const batteryUpdates = vi.spyOn(device.battService, 'updateCharacteristic')
+
+  return { accessory, batteryUpdates, device }
+}
+
+describe.each(handlers)('%s battery status', (_name, DeviceClass) => {
+  it.each([
+    [19, 1],
+    [20, 1],
+    [21, 0],
+  ])('reports battery %i with low status %i at threshold 20', async (battery, expectedLow) => {
+    const { device } = buildDevice(DeviceClass)
+
+    await device.externalUpdate({ battery })
+
+    expect(device.battService.getCharacteristic(device.hapChar.BatteryLevel).value).toBe(battery)
+    expect(device.battService.getCharacteristic(device.hapChar.StatusLowBattery).value).toBe(expectedLow)
+  })
+
+  it('repairs stale low status when the battery percentage is unchanged', async () => {
+    const { accessory, batteryUpdates, device } = buildDevice(DeviceClass, { battery: 20, low: 0 })
+
+    await device.externalUpdate({ battery: 20 })
+
+    expect(device.battService.getCharacteristic(device.hapChar.BatteryLevel).value).toBe(20)
+    expect(device.battService.getCharacteristic(device.hapChar.StatusLowBattery).value).toBe(1)
+    expect(batteryUpdates.mock.calls).toEqual([[device.hapChar.StatusLowBattery, 1]])
+    expect(accessory.log.calls).toEqual([])
+  })
+
+  it('repairs status when the threshold changes around an unchanged percentage', async () => {
+    const { accessory, batteryUpdates, device } = buildDevice(DeviceClass, {
+      battery: 20,
+      low: 0,
+      threshold: 19,
+    })
+
+    device.lowBattThreshold = 20
+    await device.externalUpdate({ battery: 20 })
+
+    expect(batteryUpdates.mock.calls).toEqual([[device.hapChar.StatusLowBattery, 1]])
+
+    batteryUpdates.mockClear()
+    device.lowBattThreshold = 19
+    await device.externalUpdate({ battery: 20 })
+
+    expect(batteryUpdates.mock.calls).toEqual([[device.hapChar.StatusLowBattery, 0]])
+    expect(accessory.log.calls).toEqual([])
+  })
+
+  it('does nothing for repeated unchanged correct samples', async () => {
+    const { accessory, batteryUpdates, device } = buildDevice(DeviceClass, {
+      battery: 20,
+      low: 1,
+    })
+
+    await device.externalUpdate({ battery: 20 })
+    await device.externalUpdate({ battery: 20 })
+
+    expect(batteryUpdates).not.toHaveBeenCalled()
+    expect(accessory.log.calls).toEqual([])
+  })
+
+  it.each([
+    [20, true],
+    [21, false],
+  ])('does not rewrite equivalent boolean low status for battery %i', async (battery, low) => {
+    const { accessory, batteryUpdates, device } = buildDevice(DeviceClass, { battery, low })
+
+    await device.externalUpdate({ battery })
+
+    expect(batteryUpdates).not.toHaveBeenCalled()
+    expect(accessory.log.calls).toEqual([])
+  })
+
+  it('updates both characteristics across low battery transitions', async () => {
+    const { accessory, batteryUpdates, device } = buildDevice(DeviceClass, {
+      battery: 21,
+      low: 0,
+    })
+
+    await device.externalUpdate({ battery: 20 })
+
+    expect(batteryUpdates.mock.calls).toEqual([
+      [device.hapChar.BatteryLevel, 20],
+      [device.hapChar.StatusLowBattery, 1],
+    ])
+    expect(accessory.log.calls).toHaveLength(1)
+
+    batteryUpdates.mockClear()
+    accessory.log.calls.length = 0
+    await device.externalUpdate({ battery: 21 })
+
+    expect(batteryUpdates.mock.calls).toEqual([
+      [device.hapChar.BatteryLevel, 21],
+      [device.hapChar.StatusLowBattery, 0],
+    ])
+    expect(accessory.log.calls).toHaveLength(1)
+  })
+
+  it.each([
+    undefined,
+    '20',
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+    -1,
+    101,
+  ])('ignores invalid battery sample %s', async (battery) => {
+    const { accessory, batteryUpdates, device } = buildDevice(DeviceClass)
+
+    await device.externalUpdate({ battery })
+
+    expect(device.cacheBatt).toBe(50)
+    expect(batteryUpdates).not.toHaveBeenCalled()
+    expect(accessory.log.calls).toEqual([])
+  })
+
+  it('does not derive low status from the constructor battery default', () => {
+    const { batteryUpdates, device } = buildDevice(DeviceClass, { seedBattery: false })
+
+    expect(device.battService.getCharacteristic(device.hapChar.BatteryLevel).value).toBe(0)
+    expect(device.battService.getCharacteristic(device.hapChar.StatusLowBattery).value).toBeFalsy()
+    expect(batteryUpdates).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
I noticed one of my H5054 leak sensors had reached exactly 20%, which is my configured low-battery threshold, but HomeKit still showed the battery as normal. For a leak sensor, that warning is the whole point: I want to change the battery before I need the sensor.

The plugin used `<` rather than `<=`, so a battery exactly at the threshold was treated as healthy. It also recalculated the low-battery status only when the percentage changed, which meant the wrong status could stick around when the next reading was still 20%.

This moves the shared battery update behavior into the base device handler and uses it for leak, thermo, and thermo-switch sensors. A valid battery reading now:

- marks the battery low at or below the configured threshold;
- repairs a stale low-battery status even when the percentage is unchanged; and
- avoids rewriting the battery level or logging it again when only the derived status needs correcting.

I wrote the regression against the unchanged code first. The tests cover the exact threshold and the unchanged-reading case across all three handlers; the full suite and lint pass on Node 22, 24, and 26.

I also tried the exact patch on my Homebridge child bridge. After the next HTTP refresh, the 20% H5054 changed from normal to low while the 40% and 50% sensors stayed normal. I watched another full polling interval with no timeout or child-bridge failure.

Thanks for taking a look.
